### PR TITLE
optimisation: improve performance across several components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 dist/
 .DS_Store
 .dev/
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -86,5 +86,9 @@ clean:
 	rm -rf ./dist/kubesolo*
 	rm -rf ./internal/core/embedded/bin
 
+.PHONY: archive
+archive:
+	tar -czf dist/kubesolo.tar.gz dist/kubesolo install.sh
+
 # Include custom make targets
 -include $(wildcard .dev/*.make)

--- a/Makefile
+++ b/Makefile
@@ -85,3 +85,6 @@ dev:
 clean:
 	rm -rf ./dist/kubesolo*
 	rm -rf ./internal/core/embedded/bin
+
+# Include custom make targets
+-include $(wildcard .dev/*.make)

--- a/build/download-deps.sh
+++ b/build/download-deps.sh
@@ -11,6 +11,7 @@ CNI_VERSION="v1.3.0"
 PORTAINER_AGENT_VERSION="2.29.2"
 COREDNS_VERSION="1.12.1"
 LOCAL_PATH_PROVISIONER_VERSION="v0.0.31"
+PAUSE_IMAGE_VERSION="3.10"
 
 # Process command line arguments
 while [[ "$#" -gt 0 ]]; do
@@ -171,3 +172,18 @@ else
 fi
 
 echo "Dependencies downloaded successfully"
+
+
+# Download Kubernetes pause image
+echo "Downloading Kubernetes pause image ${PAUSE_IMAGE_VERSION}..."
+PAUSE_IMAGE="registry.k8s.io/pause:${PAUSE_IMAGE_VERSION}"
+if ! docker image pull --platform ${OS}/${ARCH} ${PAUSE_IMAGE}; then
+    echo "Error pulling Kubernetes pause image. Skipping."
+else
+    echo "Saving Kubernetes pause image to tar..."
+    if ! docker save ${PAUSE_IMAGE} | gzip > internal/core/embedded/bin/images/pause.tar.gz; then
+        echo "Error saving Kubernetes pause image. Skipping."
+    else
+        echo "Kubernetes pause image saved successfully."
+    fi
+fi

--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -346,8 +346,10 @@ func (s *kubesolo) bootstrap() {
 		WebhookDir: filepath.Join(basePath, types.KubesoloWebhookDir),
 
 		// Image paths
-		PortainerAgentImageFile: filepath.Join(basePath, types.DefaultContainerdDir, "images", "portainer-agent.tar.gz"),
-		CorednsImageFile:        filepath.Join(basePath, types.DefaultContainerdDir, "images", "coredns.tar.gz"),
+		PortainerAgentImageFile:       filepath.Join(basePath, types.DefaultContainerdDir, "images", "portainer-agent.tar.gz"),
+		CorednsImageFile:              filepath.Join(basePath, types.DefaultContainerdDir, "images", "coredns.tar.gz"),
+		SandboxImageFile:              filepath.Join(basePath, types.DefaultContainerdDir, "images", "pause.tar.gz"),
+		LocalPathProvisionerImageFile: filepath.Join(basePath, types.DefaultContainerdDir, "images", "local-path-provisioner.tar.gz"),
 
 		// Portainer Edge
 		IsPortainerEdge: s.portainerEdgeID != "" && s.portainerEdgeKey != "",

--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,6 @@ After=network.target
 [Service]
 ExecStart=$INSTALL_PATH $CMD_ARGS
 Restart=always
-Environment="GODEBUG=madvdontneed=1"
 RestartSec=3
 OOMScoreAdjust=-500
 LimitNOFILE=65535

--- a/internal/core/embedded/embedded.go
+++ b/internal/core/embedded/embedded.go
@@ -1,7 +1,7 @@
 package embedded
 
 import (
-	"embed"
+	_ "embed"
 	"fmt"
 
 	"github.com/portainer/kubesolo/types"
@@ -14,8 +14,17 @@ var containerdShimBinary []byte
 //go:embed bin/runc
 var runcBinary []byte
 
-//go:embed bin/cni/*
-var cniPluginsFS embed.FS
+//go:embed bin/cni/bridge
+var cniPluginBridge []byte
+
+//go:embed bin/cni/host-local
+var cniPluginHostLocal []byte
+
+//go:embed bin/cni/portmap
+var cniPluginPortmap []byte
+
+//go:embed bin/cni/loopback
+var cniPluginLoopback []byte
 
 //go:embed bin/images/coredns.tar.gz
 var corednsImageFile []byte
@@ -25,6 +34,9 @@ var portainerAgentImageFile []byte
 
 //go:embed bin/images/local-path-provisioner.tar.gz
 var localPathProvisionerImageFile []byte
+
+//go:embed bin/images/pause.tar.gz
+var sandboxImageFile []byte
 
 // EnsureEmbeddedDependencies ensures all required components are available
 // it loads the containerd components, cni plugins, cni config, images, and kernel modules

--- a/internal/core/embedded/load.go
+++ b/internal/core/embedded/load.go
@@ -3,11 +3,9 @@ package embedded
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 
 	"github.com/portainer/kubesolo/internal/runtime/filesystem"
 	"github.com/portainer/kubesolo/types"
@@ -48,11 +46,6 @@ func loadContainerdComponents(embedded types.Embedded) error {
 // loadCNIPlugins creates the necessary directories and extracts and installs requried CNI plugins; "bridge", "host-local", "portmap", "loopback"
 // it then creates a symlink to the standard CNI bin directory
 func loadCNIPlugins(containerdCNIDir, containerdCNIPluginsDir string) error {
-	entries, err := fs.ReadDir(cniPluginsFS, types.DefaultEmbeddedCNIDir)
-	if err != nil {
-		return fmt.Errorf("failed to read embedded cni plugins... %v", err)
-	}
-
 	dirs := []string{
 		containerdCNIDir,
 		containerdCNIPluginsDir,
@@ -65,26 +58,20 @@ func loadCNIPlugins(containerdCNIDir, containerdCNIPluginsDir string) error {
 		}
 	}
 
-	for _, entry := range entries {
-		binaryName := entry.Name()
-		if entry.IsDir() || !slices.Contains(types.KubesoloRequiredCNIPlugins, binaryName) {
-			continue
-		}
+	plugins := []struct {
+		source      []byte
+		destination string
+		name        string
+	}{
+		{cniPluginBridge, filepath.Join(containerdCNIPluginsDir, "bridge"), "bridge"},
+		{cniPluginHostLocal, filepath.Join(containerdCNIPluginsDir, "host-local"), "host-local"},
+		{cniPluginPortmap, filepath.Join(containerdCNIPluginsDir, "portmap"), "portmap"},
+		{cniPluginLoopback, filepath.Join(containerdCNIPluginsDir, "loopback"), "loopback"},
+	}
 
-		srcFilePath := filepath.Join(types.DefaultEmbeddedCNIDir, binaryName)
-		destFilePath := filepath.Join(containerdCNIPluginsDir, binaryName)
-
-		if _, err := os.Stat(destFilePath); err == nil {
-			continue
-		}
-
-		binaryData, err := cniPluginsFS.ReadFile(srcFilePath)
-		if err != nil {
-			return fmt.Errorf("failed to read embedded %s %s... %v", "cni plugins", binaryName, err)
-		}
-
-		if err := os.WriteFile(destFilePath, binaryData, 0755); err != nil {
-			return fmt.Errorf("failed to write %s %s... %v", "cni plugins", binaryName, err)
+	for _, plugin := range plugins {
+		if err := filesystem.ExtractBinary(plugin.source, plugin.destination); err != nil {
+			return fmt.Errorf("failed to extract %s binary: %v", plugin.name, err)
 		}
 	}
 
@@ -150,7 +137,7 @@ func loadKernelModules() error {
 	return nil
 }
 
-// loadImages loads the images; "portainer-agent", "coredns" and "local-path-provisioner" into the containerd images directory
+// loadImages loads the images; "portainer-agent", "coredns", "local-path-provisioner" and "pause" into the containerd images directory
 func loadImages(containerdImagesDir string) error {
 	if err := filesystem.EnsureDirectoryExists(containerdImagesDir); err != nil {
 		return fmt.Errorf("failed to create directory %s... %w", containerdImagesDir, err)
@@ -164,6 +151,7 @@ func loadImages(containerdImagesDir string) error {
 		{portainerAgentImageFile, filepath.Join(containerdImagesDir, "portainer-agent.tar.gz"), "portainer-agent"},
 		{corednsImageFile, filepath.Join(containerdImagesDir, "coredns.tar.gz"), "coredns"},
 		{localPathProvisionerImageFile, filepath.Join(containerdImagesDir, "local-path-provisioner.tar.gz"), "local-path-provisioner"},
+		{sandboxImageFile, filepath.Join(containerdImagesDir, "pause.tar.gz"), "pause"},
 	}
 
 	for _, image := range images {

--- a/internal/system/monitoring.go
+++ b/internal/system/monitoring.go
@@ -8,17 +8,12 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// EnablePProfServer enables the pprof server for debugging
-var EnablePProfServer = false
-
 // StartMonitoring starts the system monitoring services including pprof and memory monitoring
 func StartMonitoring() {
-	if EnablePProfServer {
-		go func() {
-			log.Debug().Msg("Starting pprof server on :6060")
-			http.ListenAndServe(":6060", nil)
-		}()
-	}
+	go func() {
+		log.Debug().Msg("Starting pprof server on :6060")
+		http.ListenAndServe(":6060", nil)
+	}()
 
 	go monitorMemory()
 }

--- a/pkg/components/coredns/deployment.go
+++ b/pkg/components/coredns/deployment.go
@@ -61,7 +61,8 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset) erro
 									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU: kubesolokubernetes.ParseResourceQuantity("50m"),
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+									corev1.ResourceCPU:    kubesolokubernetes.ParseResourceQuantity("50m"),
 								},
 							},
 							Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/components/coredns/deployment.go
+++ b/pkg/components/coredns/deployment.go
@@ -58,11 +58,10 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset) erro
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("28Mi"),
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    kubesolokubernetes.ParseResourceQuantity("50m"),
-									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+									corev1.ResourceCPU: kubesolokubernetes.ParseResourceQuantity("50m"),
 								},
 							},
 							Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/components/localpath/deployment.go
+++ b/pkg/components/localpath/deployment.go
@@ -42,6 +42,10 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset) erro
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
 								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+									corev1.ResourceCPU:    kubesolokubernetes.ParseResourceQuantity("50m"),
+								},
 							},
 							Command: []string{
 								"local-path-provisioner",

--- a/pkg/components/localpath/deployment.go
+++ b/pkg/components/localpath/deployment.go
@@ -38,6 +38,11 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset) erro
 							Name:            "local-path-provisioner",
 							Image:           types.DefaultLocalPathProvisionerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+								},
+							},
 							Command: []string{
 								"local-path-provisioner",
 								"--debug",

--- a/pkg/runtime/containerd/image.go
+++ b/pkg/runtime/containerd/image.go
@@ -17,14 +17,22 @@ import (
 // importImages imports the images into the containerd registry
 func (s *service) importImages(ctx context.Context, client *client.Client, isPortainerAgent bool) error {
 	context := namespaces.WithNamespace(ctx, types.DefaultK8sNamespace)
+	if err := s.importImage(context, client, s.corednsImageFile); err != nil {
+		return err
+	}
+
+	if err := s.importImage(context, client, s.sandboxImageFile); err != nil {
+		return err
+	}
+
+	if err := s.importImage(context, client, s.localPathProvisionerImageFile); err != nil {
+		return err
+	}
+
 	if isPortainerAgent {
 		if err := s.importImage(context, client, s.portainerAgentImageFile); err != nil {
 			return err
 		}
-	}
-
-	if err := s.importImage(context, client, s.corednsImageFile); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/runtime/containerd/service.go
+++ b/pkg/runtime/containerd/service.go
@@ -8,36 +8,40 @@ import (
 
 // service is the service for the containerd
 type service struct {
-	ctx                     context.Context
-	cancel                  context.CancelFunc
-	containerdReady         chan<- struct{}
-	containerdBinaryFile    string
-	containerdImagesDir     string
-	containerdConfigFile    string
-	containerdRootDir       string
-	containerdStateDir      string
-	containerdSocketFile    string
-	runcBinaryFile          string
-	portainerAgentImageFile string
-	corednsImageFile        string
-	isPortainerEdge         bool
+	ctx                           context.Context
+	cancel                        context.CancelFunc
+	containerdReady               chan<- struct{}
+	containerdBinaryFile          string
+	containerdImagesDir           string
+	containerdConfigFile          string
+	containerdRootDir             string
+	containerdStateDir            string
+	containerdSocketFile          string
+	runcBinaryFile                string
+	portainerAgentImageFile       string
+	corednsImageFile              string
+	sandboxImageFile              string
+	localPathProvisionerImageFile string
+	isPortainerEdge               bool
 }
 
 // NewService creates a new containerd service
 func NewService(ctx context.Context, cancel context.CancelFunc, containerdReady chan<- struct{}, embedded *types.Embedded) *service {
 	return &service{
-		ctx:                     ctx,
-		cancel:                  cancel,
-		containerdReady:         containerdReady,
-		containerdBinaryFile:    embedded.ContainerdBinaryFile,
-		containerdImagesDir:     embedded.ContainerdImagesDir,
-		containerdConfigFile:    embedded.ContainerdConfigFile,
-		containerdRootDir:       embedded.ContainerdRootDir,
-		containerdStateDir:      embedded.ContainerdStateDir,
-		containerdSocketFile:    embedded.ContainerdSocketFile,
-		runcBinaryFile:          embedded.RuncBinaryFile,
-		portainerAgentImageFile: embedded.PortainerAgentImageFile,
-		corednsImageFile:        embedded.CorednsImageFile,
-		isPortainerEdge:         embedded.IsPortainerEdge,
+		ctx:                           ctx,
+		cancel:                        cancel,
+		containerdReady:               containerdReady,
+		containerdBinaryFile:          embedded.ContainerdBinaryFile,
+		containerdImagesDir:           embedded.ContainerdImagesDir,
+		containerdConfigFile:          embedded.ContainerdConfigFile,
+		containerdRootDir:             embedded.ContainerdRootDir,
+		containerdStateDir:            embedded.ContainerdStateDir,
+		containerdSocketFile:          embedded.ContainerdSocketFile,
+		runcBinaryFile:                embedded.RuncBinaryFile,
+		portainerAgentImageFile:       embedded.PortainerAgentImageFile,
+		corednsImageFile:              embedded.CorednsImageFile,
+		sandboxImageFile:              embedded.SandboxImageFile,
+		localPathProvisionerImageFile: embedded.LocalPathProvisionerImageFile,
+		isPortainerEdge:               embedded.IsPortainerEdge,
 	}
 }

--- a/types/const.go
+++ b/types/const.go
@@ -32,9 +32,9 @@ const (
 	DefaultPortainerAgentImage            = "portainer/agent:2.29.2"
 	DefaultCoreDNSImage                   = "coredns/coredns:1.12.1"
 	DefaultLocalPathProvisionerImage      = "rancher/local-path-provisioner:v0.0.31"
-	DefaultGCPercent                      = 30
+	DefaultGCPercent                      = 50
 	DefaultContextTimeout                 = 15 * time.Second
-	DefaultMemoryLimit                    = 75 * 1024 * 1024
+	DefaultMemoryLimit                    = 160 * 1024 * 1024
 	DefaultComponentSleep                 = 5 * time.Second
 	DefaultRetryCount                     = 12
 )

--- a/types/types.go
+++ b/types/types.go
@@ -102,8 +102,10 @@ type Embedded struct {
 	WebhookDir string
 
 	// Images
-	PortainerAgentImageFile string
-	CorednsImageFile        string
+	PortainerAgentImageFile       string
+	CorednsImageFile              string
+	SandboxImageFile              string
+	LocalPathProvisionerImageFile string
 
 	// Portainer Edge
 	IsPortainerEdge bool

--- a/types/var.go
+++ b/types/var.go
@@ -6,5 +6,4 @@ var (
 	KubesoloKineDir              = filepath.Join(DefaultKineDir, "db")
 	KubesoloControllerManagerDir = filepath.Join(DefaultControllerManagerDir, "config")
 	KubesoloWebhookDir           = filepath.Join(DefaultPKIDir, "webhook")
-	KubesoloRequiredCNIPlugins   = []string{"bridge", "host-local", "portmap", "loopback"}
 )


### PR DESCRIPTION
This PR helps improving:

- Bumped `DefaultGCPercent` and `DefaultMemoryLimit` to fix CPU spikes
  - Fixes https://github.com/portainer/kubesolo/issues/11
- Preloaded required CNI plugins separately to reduce the overall binary size
- Lowered memory limit for `coredns`
- Introduced memory limit for `local-path-provisioner`
- Fixed `pprof` flag not being inherited properly