### PR TITLE
fix: use kubesolo version as k8s version build metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ GOARCH ?= $(shell go env GOARCH)
 OUTPUT ?= ./dist/kubesolo
 
 VERSION ?= $(shell git describe --tags --always --dirty)
+K8S_VERSION ?= $(shell grep -Po '(?<=k8s\.io/kubernetes )v.*' ./go.mod)
 COMMIT ?= $(shell git rev-parse --short HEAD)
 BUILD_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-LDFLAGS_STRING = -s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}
+LDFLAGS_STRING = -s -w -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE} -X k8s.io/component-base/version.gitVersion=${K8S_VERSION}+kubesolo-${VERSION}
 
 # Cross-compilation settings
 CC_arm64 = aarch64-linux-gnu-gcc


### PR DESCRIPTION
When `k8s.io/component-base/version.gitVersion` is not explicitly set, the k3s package version is used.
Go package versions are not semver.
This leads to the k3s version part to be interpreted a kubernetes pre-release rather than as build metadata.
Helm charts that require non pre-release kubernetes versions, among other version checks fail as a result.

Fixes #43 