### PR TITLE
fix: fully-qualified image references and local-path-provisioner OOM fixFix/bug fixes

### DIFF
--- a/pkg/components/localpath/deployment.go
+++ b/pkg/components/localpath/deployment.go
@@ -40,10 +40,10 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset) erro
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("128Mi"),
 								},
 								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("20Mi"),
+									corev1.ResourceMemory: kubesolokubernetes.ParseResourceQuantity("32Mi"),
 									corev1.ResourceCPU:    kubesolokubernetes.ParseResourceQuantity("50m"),
 								},
 							},

--- a/types/const.go
+++ b/types/const.go
@@ -26,10 +26,10 @@ const (
 	DefaultKineDir                   = "kine"
 	DefaultKineSocket                = "kine.sock"
 	DefaultControllerManagerDir      = "controller-manager"
-	DefaultSandboxImage              = "portainer/pause:latest"
-	DefaultPortainerAgentImage       = "portainer/agent:2.39.0"
-	DefaultCoreDNSImage              = "coredns/coredns:1.14.1"
-	DefaultLocalPathProvisionerImage = "rancher/local-path-provisioner:v0.0.34"
+	DefaultSandboxImage              = "docker.io/portainer/pause:latest"
+	DefaultPortainerAgentImage       = "docker.io/portainer/agent:2.39.0"
+	DefaultCoreDNSImage              = "docker.io/coredns/coredns:1.14.1"
+	DefaultLocalPathProvisionerImage = "docker.io/rancher/local-path-provisioner:v0.0.34"
 	DefaultLocalPathStorageDir       = "local-path-storage"
 	DefaultWebhookReadWriteTimeout   = 10 * time.Second
 	DefaultWebhookIdleTimeout        = 30 * time.Second


### PR DESCRIPTION
## Description

Two small, independent bug fixes:

### 1. Use fully-qualified `docker.io/` image references

**Problem:** Image constants use short names (e.g., `portainer/pause:latest`) which fail on containerd runtimes that don't default to `docker.io` as the registry (containerd requires fully-qualified references unlike Docker).

**Fix:** Prefix all image constants with `docker.io/` in `types/const.go`.

### 2. Increase local-path-provisioner memory limits

**Problem:** The memory limit of `20Mi` is too low — the provisioner gets OOM-killed by the kernel under normal operation, causing persistent volume claims to hang indefinitely.

**Fix:** Bump memory limit from `20Mi` → `128Mi` and request from `20Mi` → `32Mi`. These values are consistent with the [upstream local-path-provisioner defaults](https://github.com/rancher/local-path-provisioner).

### Files Changed

- `types/const.go` — Add `docker.io/` prefix to 4 image constants
- `pkg/components/localpath/deployment.go` — Update memory limit/request

### Testing

- Verified containerd pulls images correctly with fully-qualified references
- Confirmed local-path-provisioner runs without OOM kills under normal PVC workloads
