### PR TITLE
fix: cgroupv2, nftables proxy mode, hostname normalization, and kernel module loading

### DIFF
--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -272,6 +272,9 @@ func (s *kubesolo) bootstrap() {
 	logging.SetLoggingLevel("INFO")
 	logging.ConfigureK8sDefaultLogging()
 
+	// Load required kernel modules before any networking setup
+	system.LoadRequiredModules()
+
 	// System Node IP
 	nodeIP, err := network.GetNodeIP()
 	if err != nil {

--- a/internal/core/embedded/load.go
+++ b/internal/core/embedded/load.go
@@ -99,15 +99,13 @@ func loadCNIConfig(containerdCNIConfigDir, containerdCNIConfigFile string) error
 	return nil
 }
 
-// loadKernelModules loads the necessary kernel modules
-// "overlay", "br_netfilter", "ip_tables", "iptable_filter", "iptable_nat", "nf_conntrack"
+// loadKernelModules loads the necessary kernel modules.
+// Legacy ip_tables modules are attempted but failures are non-fatal since
+// nova8OS uses nf_tables natively — iptables-nft works via nft_compat.
 func loadKernelModules() error {
 	essentialModules := []string{
 		"overlay",
 		"br_netfilter",
-		"ip_tables",
-		"iptable_filter",
-		"iptable_nat",
 		"nf_conntrack",
 	}
 
@@ -115,6 +113,19 @@ func loadKernelModules() error {
 		command := exec.Command("modprobe", module)
 		if err := command.Run(); err != nil {
 			return fmt.Errorf("failed to load essential kernel module %s... %v", module, err)
+		}
+	}
+
+	// Legacy iptables modules — soft-fail since nova8OS uses nf_tables backend
+	optionalModules := []string{
+		"ip_tables",
+		"iptable_filter",
+		"iptable_nat",
+	}
+	for _, module := range optionalModules {
+		command := exec.Command("modprobe", module)
+		if err := command.Run(); err != nil {
+			log.Debug().Str("component", "embedded").Msgf("optional module %s not available (nf_tables backend used) — skipping", module)
 		}
 	}
 

--- a/internal/system/host.go
+++ b/internal/system/host.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"os"
+	"strings"
 
 	"github.com/portainer/kubesolo/types"
 	"github.com/rs/zerolog/log"
@@ -16,5 +17,5 @@ func GetHostname() string {
 		log.Warn().Str("component", "kubesolo").Msg("failed to get hostname, using default value")
 		hostname = types.DefaultNodeName
 	}
-	return hostname
+	return strings.ToLower(hostname)
 }

--- a/internal/system/modules.go
+++ b/internal/system/modules.go
@@ -1,0 +1,38 @@
+package system
+
+import (
+	"os/exec"
+
+	"github.com/rs/zerolog/log"
+)
+
+// requiredModules lists kernel modules needed by kubelet and kube-proxy.
+// Modules that are built-in to the kernel will fail modprobe gracefully.
+var requiredModules = []string{
+	"br_netfilter",
+	"overlay",
+	"xt_MASQUERADE",
+	"xt_conntrack",
+	"xt_comment",
+	"xt_addrtype",
+	"xt_multiport",
+	"xt_nat",
+	"xt_recent",
+	"xt_set",
+	"xt_statistic",
+	"xt_nfacct",
+}
+
+// LoadRequiredModules attempts to load kernel modules required by Kubernetes
+// networking components. Failures are logged as warnings and do not prevent
+// startup — the module may be built-in or simply unavailable.
+func LoadRequiredModules() {
+	for _, mod := range requiredModules {
+		out, err := exec.Command("modprobe", mod).CombinedOutput()
+		if err != nil {
+			log.Warn().Str("component", "kubesolo").Msgf("modprobe %s: %v (output: %s) — module may be built-in or unavailable", mod, err, string(out))
+			continue
+		}
+		log.Debug().Str("component", "kubesolo").Msgf("loaded kernel module: %s", mod)
+	}
+}

--- a/internal/system/modules.go
+++ b/internal/system/modules.go
@@ -1,16 +1,20 @@
 package system
 
 import (
+	"os"
 	"os/exec"
 
 	"github.com/rs/zerolog/log"
 )
 
-// requiredModules lists kernel modules needed by kubelet and kube-proxy.
-// Modules that are built-in to the kernel will fail modprobe gracefully.
-var requiredModules = []string{
+// commonModules are needed regardless of proxy mode
+var commonModules = []string{
 	"br_netfilter",
 	"overlay",
+}
+
+// iptablesModules are needed when kube-proxy uses iptables mode
+var iptablesModules = []string{
 	"xt_MASQUERADE",
 	"xt_conntrack",
 	"xt_comment",
@@ -23,11 +27,30 @@ var requiredModules = []string{
 	"xt_nfacct",
 }
 
+// nftablesModules are needed when kube-proxy uses nftables mode
+var nftablesModules = []string{
+	"nft_numgen",
+	"nft_redir",
+	"nft_limit",
+	"nft_tproxy",
+}
+
 // LoadRequiredModules attempts to load kernel modules required by Kubernetes
-// networking components. Failures are logged as warnings and do not prevent
-// startup — the module may be built-in or simply unavailable.
+// networking components. Detects whether the host supports iptables or nftables
+// and loads the appropriate module set. Failures are logged as warnings and do
+// not prevent startup — the module may be built-in or simply unavailable.
 func LoadRequiredModules() {
-	for _, mod := range requiredModules {
+	modules := commonModules
+
+	if _, err := os.Stat("/proc/net/ip_tables_names"); err != nil {
+		log.Info().Str("component", "kubesolo").Msg("iptables kernel modules not available, loading nftables modules")
+		modules = append(modules, nftablesModules...)
+	} else {
+		log.Info().Str("component", "kubesolo").Msg("iptables kernel modules available, loading iptables modules")
+		modules = append(modules, iptablesModules...)
+	}
+
+	for _, mod := range modules {
 		out, err := exec.Command("modprobe", mod).CombinedOutput()
 		if err != nil {
 			log.Warn().Str("component", "kubesolo").Msgf("modprobe %s: %v (output: %s) — module may be built-in or unavailable", mod, err, string(out))

--- a/internal/system/modules.go
+++ b/internal/system/modules.go
@@ -1,55 +1,66 @@
 package system
 
 import (
-	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 )
 
-// commonModules are needed regardless of proxy mode
+// commonModules are needed regardless of networking backend
 var commonModules = []string{
 	"br_netfilter",
 	"overlay",
 }
 
-// iptablesModules are needed when kube-proxy uses iptables mode
-var iptablesModules = []string{
-	"xt_MASQUERADE",
-	"xt_conntrack",
+// cniXtablesModules are xtables match/target modules required by the CNI bridge
+// and portmap plugins. These are needed on both legacy iptables and iptables-nft
+// systems (nft_compat translates them on nftables kernels).
+var cniXtablesModules = []string{
 	"xt_comment",
+	"xt_conntrack",
+	"xt_MASQUERADE",
 	"xt_addrtype",
 	"xt_multiport",
 	"xt_nat",
-	"xt_recent",
-	"xt_set",
-	"xt_statistic",
-	"xt_nfacct",
 }
 
-// nftablesModules are needed when kube-proxy uses nftables mode
+// nftablesModules are loaded on systems using nf_tables (e.g., nova8OS).
+// Includes nft_compat for iptables-nft translation of xt_* extensions.
 var nftablesModules = []string{
+	"nft_compat",
 	"nft_numgen",
 	"nft_redir",
 	"nft_limit",
 	"nft_tproxy",
 }
 
-// LoadRequiredModules attempts to load kernel modules required by Kubernetes
-// networking components. Detects whether the host supports iptables or nftables
-// and loads the appropriate module set. Failures are logged as warnings and do
-// not prevent startup — the module may be built-in or simply unavailable.
-func LoadRequiredModules() {
-	modules := commonModules
+// iptablesModules are loaded on legacy iptables systems (e.g., Ubuntu)
+var iptablesModules = []string{
+	"ip_tables",
+	"iptable_filter",
+	"iptable_nat",
+	"nf_conntrack",
+}
 
-	if _, err := os.Stat("/proc/net/ip_tables_names"); err != nil {
-		log.Info().Str("component", "kubesolo").Msg("iptables kernel modules not available, loading nftables modules")
+// LoadRequiredModules attempts to load kernel modules required by Kubernetes
+// networking components. Detects whether the host uses nf_tables or legacy
+// iptables and loads the appropriate backend modules, plus xtables match/target
+// modules needed by the CNI bridge plugin in both cases.
+// Failures are logged as warnings and do not prevent startup — the module may
+// be built-in or simply unavailable.
+func LoadRequiredModules() {
+	modules := append(commonModules, cniXtablesModules...)
+
+	if isNftBackend() {
+		log.Info().Str("component", "kubesolo").Msg("nf_tables backend detected, loading nftables modules")
 		modules = append(modules, nftablesModules...)
 	} else {
-		log.Info().Str("component", "kubesolo").Msg("iptables kernel modules available, loading iptables modules")
+		log.Info().Str("component", "kubesolo").Msg("legacy iptables backend detected, loading iptables modules")
 		modules = append(modules, iptablesModules...)
 	}
 
+	log.Debug().Str("component", "kubesolo").Msgf("loading %d kernel modules", len(modules))
 	for _, mod := range modules {
 		out, err := exec.Command("modprobe", mod).CombinedOutput()
 		if err != nil {
@@ -58,4 +69,17 @@ func LoadRequiredModules() {
 		}
 		log.Debug().Str("component", "kubesolo").Msgf("loaded kernel module: %s", mod)
 	}
+}
+
+// isNftBackend returns true if the iptables binary uses the nf_tables backend.
+// Parses "iptables --version" output which contains "(nf_tables)" or "(legacy)".
+func isNftBackend() bool {
+	out, err := exec.Command("iptables", "--version").CombinedOutput()
+	if err != nil {
+		log.Warn().Str("component", "kubesolo").Msgf("failed to detect iptables backend: %v — assuming nf_tables", err)
+		return true
+	}
+	version := string(out)
+	log.Debug().Str("component", "kubesolo").Msgf("iptables version: %s", strings.TrimSpace(version))
+	return strings.Contains(version, "(nf_tables)")
 }

--- a/pkg/kubernetes/kubeproxy/executor.go
+++ b/pkg/kubernetes/kubeproxy/executor.go
@@ -2,6 +2,7 @@ package kubeproxy
 
 import (
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -12,6 +13,19 @@ import (
 
 	proxy "k8s.io/kubernetes/cmd/kube-proxy/app"
 )
+
+// flushNftablesNat clears any existing nftables nat table rules before
+// kube-proxy starts. This prevents conflicts between native nftables rules
+// (e.g., from Podman's netavark) and kube-proxy's iptables-nft translation
+// layer, which cannot coexist with pre-existing native nftables entries.
+func flushNftablesNat() {
+	out, err := exec.Command("nft", "flush", "table", "ip", "nat").CombinedOutput()
+	if err != nil {
+		log.Debug().Str("component", "kubeproxy").Msgf("nft flush table ip nat: %v (output: %s) — table may not exist, skipping", err, string(out))
+		return
+	}
+	log.Info().Str("component", "kubeproxy").Msg("flushed nftables ip nat table to avoid iptables-nft conflicts")
+}
 
 // Run starts the kube proxy in the following order:
 // 1. it sets the kube proxy flags
@@ -29,6 +43,7 @@ func (s *service) Run(kubeletReadyCh chan struct{}) error {
 	time.Sleep(types.DefaultComponentSleep)
 	if err := kubesoloservice.RunServiceWithStartupCheck(func() error {
 		<-kubeletReadyCh
+		flushNftablesNat()
 		s.wg.Go(func() {
 			if err := command.ExecuteContext(s.ctx); err != nil {
 				log.Error().Str("component", "kubeproxy").Msgf("kubeproxy exited with error: %v", err)

--- a/pkg/kubernetes/kubeproxy/flags.go
+++ b/pkg/kubernetes/kubeproxy/flags.go
@@ -1,12 +1,28 @@
 package kubeproxy
 
 import (
+	"os"
+
 	"github.com/portainer/kubesolo/types"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
 
+// detectProxyMode returns "nftables" if the iptables kernel modules are
+// unavailable (e.g., ip_tables or xt_REJECT not compiled), otherwise "iptables".
+// kube-proxy nftables mode is stable since Kubernetes 1.31.
+func detectProxyMode() string {
+	if _, err := os.Stat("/proc/net/ip_tables_names"); err != nil {
+		log.Info().Str("component", "kubeproxy").Msg("iptables kernel modules not available, using nftables proxy mode")
+		return "nftables"
+	}
+	return "iptables"
+}
+
 func (s *service) configureKubeProxyFlags(command *cobra.Command) {
 	flags := command.Flags()
+
+	proxyMode := detectProxyMode()
 
 	// networking settings
 	_ = flags.Set("kubeconfig", s.adminKubeconfigFile)
@@ -17,11 +33,14 @@ func (s *service) configureKubeProxyFlags(command *cobra.Command) {
 	_ = flags.Set("oom-score-adj", "-998")
 	_ = flags.Set("profiling", "false")
 
-	// iptables settings
-	_ = flags.Set("iptables-masquerade-bit", "14")
-	_ = flags.Set("masquerade-all", "true")
-	_ = flags.Set("proxy-mode", "iptables")
+	// proxy mode and conntrack settings
+	_ = flags.Set("proxy-mode", proxyMode)
 	_ = flags.Set("conntrack-max-per-core", "1024")
 	_ = flags.Set("conntrack-min", "1024")
 	_ = flags.Set("min-sync-period", "10s")
+
+	if proxyMode == "iptables" {
+		_ = flags.Set("iptables-masquerade-bit", "14")
+		_ = flags.Set("masquerade-all", "true")
+	}
 }

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -9,6 +9,14 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// isCgroupV2 returns true if the host uses the cgroupv2 unified hierarchy.
+// When true, runc must use the systemd cgroup driver (SystemdCgroup=true)
+// instead of the cgroupfs driver which generates cgroupv1-style paths.
+func isCgroupV2() bool {
+	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
+	return err == nil
+}
+
 // writeConfigFile writes the containerd config to a file
 func (s *service) writeContainerdConfigFile() error {
 	tree, err := toml.TreeFromMap(s.generateContainerdConfig())
@@ -108,7 +116,8 @@ func (s *service) generateContainerdConfig() map[string]any {
 							"sandboxer":         "podsandbox",
 							"io_type":           "",
 							"options": map[string]any{
-								"BinaryName": s.runcBinaryFile,
+								"BinaryName":    s.runcBinaryFile,
+								"SystemdCgroup": isCgroupV2(),
 							},
 						},
 					},


### PR DESCRIPTION
## Description

A set of fixes that make KubeSolo work correctly on modern Linux systems using cgroupv2 and nftables. All patches are backward-compatible and safe on systems where the patched conditions do not apply (auto-detection with soft-fail).

### 1. cgroupv2 auto-detection (`pkg/runtime/containerd/config.go`)

**Problem:** The generated `config.toml` omits `SystemdCgroup`, causing runc to default to the cgroupfs driver. On cgroupv2 hosts, this generates cgroupv1-style cgroup paths that don't exist:

```
runc create failed: unable to apply cgroup configuration:
failed to write cgroup.procs: no such file or directory
```

**Fix:** Add `isCgroupV2()` helper that checks for `/sys/fs/cgroup/cgroup.controllers` and sets `SystemdCgroup=true` when cgroupv2 is detected.

### 2. Hostname normalization (`internal/system/host.go`)

**Problem:** `GetHostname()` returns the raw kernel hostname which may be mixed-case. Kubernetes normalizes node names to lowercase internally, but PKI certificates and RBAC bindings use the original value, causing authorization failures:

```
nodes "nova8os" is forbidden: User "system:node:nova8OS" cannot get resource "nodes"
```

**Fix:** Apply `strings.ToLower()` to the hostname in `GetHostname()` so all consumers use a consistent lowercase value.

### 3. nftables nat table flush (`pkg/kubernetes/kubeproxy/executor.go`)

**Problem:** On systems running Podman with netavark, native nftables rules exist in the `ip nat` table before KubeSolo starts. When kube-proxy inserts rules via the iptables-nft translation layer, it conflicts with these pre-existing entries.

**Fix:** Add `flushNftablesNat()` that runs `nft flush table ip nat` after kubelet is ready but before kube-proxy starts. Soft-fails if the nat table doesn't exist.

### 4. Automatic nftables proxy mode (`pkg/kubernetes/kubeproxy/flags.go`)

**Problem:** kube-proxy was hardcoded to `--proxy-mode=iptables`, which requires `ip_tables` and `xt_REJECT` kernel modules. Systems using nftables natively may not compile these legacy modules.

**Fix:** Add `detectProxyMode()` that checks `/proc/net/ip_tables_names` to determine iptables support. Falls back to `--proxy-mode=nftables` (stable since Kubernetes 1.31) when unavailable. Iptables-specific flags are only set in iptables mode.

### 5. Pre-flight kernel module loading (`internal/system/modules.go`, `cmd/kubesolo/main.go`)

**Problem:** KubeSolo requires several kernel modules for networking (`br_netfilter`, `overlay`, various `xt_*` modules). When not loaded, startup fails with cryptic errors.

**Fix:** Add `LoadRequiredModules()` called early in `bootstrap()` that:
- Detects nf_tables vs legacy iptables backend via `iptables --version`
- Loads common modules (`br_netfilter`, `overlay`) plus CNI xtables modules
- Loads backend-specific modules (nft_* or ip_tables/iptable_*)
- Each module soft-fails with a warning if unavailable

### 6. Optional legacy iptables modules (`internal/core/embedded/load.go`)

**Fix:** Move `ip_tables`, `iptable_filter`, `iptable_nat` to optional module loading — failures are logged at debug level instead of blocking startup.

### Files Changed

| File | Change |
|------|--------|
| `cmd/kubesolo/main.go` | Call `LoadRequiredModules()` in `bootstrap()` |
| `internal/system/host.go` | Lowercase hostname |
| `internal/system/modules.go` | **New** - kernel module loading with nft/iptables detection |
| `internal/core/embedded/load.go` | Make legacy iptables modules optional |
| `pkg/kubernetes/kubeproxy/executor.go` | Flush nftables nat before kube-proxy |
| `pkg/kubernetes/kubeproxy/flags.go` | Auto-detect proxy mode |
| `pkg/runtime/containerd/config.go` | cgroupv2 detection + `SystemdCgroup` |

### Testing

- Tested on cgroupv2 systems (nova8OS, Fedora 40), containers start correctly
- Tested on cgroupv1 systems, no behavior change (SystemdCgroup=false)
- Verified kube-proxy starts in nftables mode on nft-only kernels
- Verified kube-proxy uses iptables mode on systems with ip_tables loaded
- Confirmed mixed-case hostnames no longer cause RBAC failures