### PR TITLE
feat: optimize binary size, crun, zstd compression, online/offline build variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ release-workflow-deps: install-cross-compilers install-musl-cross-compilers
 deps:
 	./build/download-deps.sh --os=$(GOOS) --arch=$(GOARCH)
 
+.PHONY: deps-offline
+deps-offline:
+	./build/download-deps.sh --os=$(GOOS) --arch=$(GOARCH) --offline
+
 # Generic build function that uses the correct cross-compiler based on GOARCH
 .PHONY: build
 build: lint deps
@@ -72,6 +76,27 @@ else ifeq ($(GOARCH),riscv64)
 else ifeq ($(GOARCH),arm)
 	CC=$(CC_arm) CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS_EXTRA)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-ldflags="${LDFLAGS_STRING}" -a \
+		-o $(OUTPUT) ./cmd/kubesolo/main.go
+else
+	@echo "Unsupported architecture: $(GOARCH)"
+	@exit 1
+endif
+
+# Build offline variant with all OCI images embedded (air-gapped deployments)
+.PHONY: build-offline
+build-offline: lint deps-offline
+	@mkdir -p $(dir $(OUTPUT))
+ifeq ($(GOARCH),arm64)
+	CC=$(CC_arm64) CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS_EXTRA)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+		-tags offline -ldflags="${LDFLAGS_STRING}" -a \
+		-o $(OUTPUT) ./cmd/kubesolo/main.go
+else ifeq ($(GOARCH),amd64)
+	CC=$(CC_amd64) CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS_EXTRA)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+		-tags offline -ldflags="${LDFLAGS_STRING}" -a \
+		-o $(OUTPUT) ./cmd/kubesolo/main.go
+else ifeq ($(GOARCH),riscv64)
+	CC=$(CC_riscv64) CGO_ENABLED=1 CGO_CFLAGS="$(CGO_CFLAGS_EXTRA)" GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
+		-tags offline -ldflags="${LDFLAGS_STRING}" -a \
 		-o $(OUTPUT) ./cmd/kubesolo/main.go
 else
 	@echo "Unsupported architecture: $(GOARCH)"

--- a/build/crun.Dockerfile
+++ b/build/crun.Dockerfile
@@ -1,0 +1,64 @@
+# crun build for arm/v7 using Debian Linux (glibc)
+#
+# Strategy: Build natively inside an arm/v7 Debian container via QEMU.
+# This produces a glibc-linked binary that matches the current installer
+# expectations for linux-arm artifacts.
+#
+# Build with: docker build --platform linux/arm/v7 -f ./build/crun.Dockerfile -t crun-arm32-builder .
+# Extract with:
+#   docker create --name crun-extract crun-arm32-builder noop
+#   docker cp crun-extract:/crun ./internal/core/embedded/bin/crun
+#   docker rm crun-extract
+
+FROM --platform=linux/arm/v7 debian:12-slim AS builder
+
+ARG CRUN_VERSION=1.26
+
+# Install build dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        ca-certificates \
+        git \
+        go-md2man \
+        gperf \
+        libcap-dev \
+        libseccomp-dev \
+        libsystemd-dev \
+        libtool \
+        linux-libc-dev \
+        pkg-config \
+        python3 \
+        && rm -rf /var/lib/apt/lists/*
+
+# Clone crun repository
+RUN git clone --recursive https://github.com/containers/crun.git /src/crun
+WORKDIR /src/crun
+
+# Checkout specific version
+RUN git checkout ${CRUN_VERSION} && \
+    git submodule update --init --recursive
+
+# Generate configure script
+RUN ./autogen.sh
+
+# Configure for glibc build with systemd support to match upstream features
+RUN ./configure \
+    --enable-systemd \
+    --enable-embedded-yajl \
+    --with-cap \
+    --with-seccomp
+
+# Build
+RUN make -j"$(nproc)"
+
+# Package output
+RUN mkdir -p /output/bin && \
+    cp crun /output/bin/ && \
+    strip /output/bin/crun
+
+# Final stage: copy the built binary to a clean image
+FROM scratch
+COPY --from=builder /output/bin/crun /crun

--- a/build/download-deps.sh
+++ b/build/download-deps.sh
@@ -96,17 +96,44 @@ rm internal/core/embedded/bin/containerd.tar.gz
 zstd -19 --rm -q internal/core/embedded/bin/containerd/bin/containerd-shim-runc-v2
 
 # Download crun - add error checking
-# crun does not publish 32-bit ARM binaries; fail early for unsupported architectures
+# crun does not publish 32-bit ARM binaries; build from source for arm
 if [ "${ARCH}" = "arm" ]; then
-    echo "Error: crun does not provide pre-built binaries for 32-bit ARM (armhf)."
-    echo "Please build crun from source or use a supported architecture (amd64, arm64, riscv64)."
-    exit 1
-fi
+    echo "Building crun ${CRUN_VERSION} for ${OS}-${ARCH} using Docker..."
 
-echo "Downloading crun ${CRUN_VERSION} for ${ARCH}..."
-if ! curl -L -f --silent -o internal/core/embedded/bin/crun https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}; then
-    echo "Error downloading crun. Please check the version and URL."
-    exit 1
+    # Check if Docker is available
+    if ! command -v docker &> /dev/null; then
+        echo "Docker is required to build crun for ARM but is not installed."
+        exit 1
+    fi
+
+    # Build the crun image with the specified version (native arm/v7 via QEMU)
+    if ! docker build --platform linux/arm/v7 -f build/crun.Dockerfile --build-arg CRUN_VERSION=${CRUN_VERSION} -t crun-arm32-builder .; then
+        echo "Error building crun Docker image."
+        exit 1
+    fi
+
+    # Extract the compiled binary
+    echo "Extracting crun binary..."
+    if ! docker create --name temp-crun crun-arm32-builder noop; then
+        echo "Error creating temporary container."
+        exit 1
+    fi
+
+    if ! docker cp temp-crun:/crun internal/core/embedded/bin/crun; then
+        echo "Error extracting crun binary from container."
+        docker rm temp-crun 2>/dev/null
+        exit 1
+    fi
+
+    docker rm temp-crun
+
+    echo "Successfully built crun for ARM."
+else
+    echo "Downloading crun ${CRUN_VERSION} for ${ARCH}..."
+    if ! curl -L -f --silent -o internal/core/embedded/bin/crun https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}; then
+        echo "Error downloading crun. Please check the version and URL."
+        exit 1
+    fi
 fi
 zstd -19 --rm -q internal/core/embedded/bin/crun
 

--- a/build/download-deps.sh
+++ b/build/download-deps.sh
@@ -6,12 +6,15 @@ OS="linux"
 ARCH="amd64"
 # Set versions
 CONTAINERD_VERSION="2.1.5"
-RUNC_VERSION="v1.3.3"
+CRUN_VERSION="1.26"
 CNI_VERSION="v1.9.0"
 PORTAINER_AGENT_VERSION="2.39.0"
 COREDNS_VERSION="1.14.1"
 LOCAL_PATH_PROVISIONER_VERSION="v0.0.34"
 PAUSE_IMAGE_VERSION="3.10"
+
+# Offline mode embeds all OCI images; online mode (default) skips optional images
+OFFLINE=false
 
 # Process command line arguments
 while [[ "$#" -gt 0 ]]; do
@@ -20,11 +23,12 @@ while [[ "$#" -gt 0 ]]; do
         --os) OS="$2"; shift 2 ;;
         --arch=*) ARCH="${1#*=}"; shift ;;
         --arch) ARCH="$2"; shift 2 ;;
+        --offline) OFFLINE=true; shift ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
 done
 
-echo "Using OS: ${OS}, Architecture: ${ARCH}"
+echo "Using OS: ${OS}, Architecture: ${ARCH}, Offline: ${OFFLINE}"
 
 # Create bin directories
 mkdir -p internal/core/embedded/bin/containerd
@@ -86,23 +90,25 @@ else
     fi
 fi
 
-# Extract containerd binaries
+# Extract containerd binaries and zstd-compress the shim for embedding
 tar -xzf internal/core/embedded/bin/containerd.tar.gz -C internal/core/embedded/bin/containerd
 rm internal/core/embedded/bin/containerd.tar.gz
+zstd -19 --rm -q internal/core/embedded/bin/containerd/bin/containerd-shim-runc-v2
 
-# Download runc - add error checking
-# Map architecture to runc filename (arm -> armhf for runc releases)
-RUNC_ARCH=${ARCH}
+# Download crun - add error checking
+# crun does not publish 32-bit ARM binaries; fail early for unsupported architectures
 if [ "${ARCH}" = "arm" ]; then
-    RUNC_ARCH="armhf"
-fi
-
-echo "Downloading runc ${RUNC_VERSION} for ${ARCH} (using runc.${RUNC_ARCH})..."
-if ! curl -L -f --silent -o internal/core/embedded/bin/runc https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.${RUNC_ARCH}; then
-    echo "Error downloading runc. Please check the version and URL."
+    echo "Error: crun does not provide pre-built binaries for 32-bit ARM (armhf)."
+    echo "Please build crun from source or use a supported architecture (amd64, arm64, riscv64)."
     exit 1
 fi
-chmod +x internal/core/embedded/bin/runc
+
+echo "Downloading crun ${CRUN_VERSION} for ${ARCH}..."
+if ! curl -L -f --silent -o internal/core/embedded/bin/crun https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-linux-${ARCH}; then
+    echo "Error downloading crun. Please check the version and URL."
+    exit 1
+fi
+zstd -19 --rm -q internal/core/embedded/bin/crun
 
 # Download CNI plugins - add error checking
 echo "Downloading CNI plugins ${CNI_VERSION} for ${OS}-${ARCH}..."
@@ -120,6 +126,11 @@ fi
 tar -xzf internal/core/embedded/bin/cni/cni-plugins.tgz -C internal/core/embedded/bin/cni
 rm internal/core/embedded/bin/cni/cni-plugins.tgz
 
+# zstd-compress CNI plugin binaries for embedding
+for plugin in bridge host-local portmap loopback; do
+    zstd -19 --rm -q "internal/core/embedded/bin/cni/${plugin}"
+done
+
 # Download container images
 echo "Checking if Crane is available..."
 if ! command -v crane &> /dev/null; then
@@ -129,52 +140,53 @@ if ! command -v crane &> /dev/null; then
     rm -f go-containerregistry.tar.gz
 fi
 
-# Download Portainer Agent (skip for riscv64 as it's not supported)
-if [ "${ARCH}" != "riscv64" ]; then
-    echo "Downloading Portainer Agent ${PORTAINER_AGENT_VERSION}..."
-    PORTAINER_IMAGE="portainer/agent:${PORTAINER_AGENT_VERSION}"
-    # Pull the image as uncompressed tar
-    if ! crane pull --platform ${OS}/${ARCH} ${PORTAINER_IMAGE} internal/core/embedded/bin/images/portainer-agent.tar; then
-        echo "Error pulling Portainer Agent image."
-        exit 1
-    fi
-    # Compress it to save space
-    if ! gzip -f internal/core/embedded/bin/images/portainer-agent.tar; then
-        echo "Error compressing Portainer Agent image."
-        exit 1
-    fi
-    echo "Portainer Agent image saved and compressed successfully."
-else
-    echo "Skipping Portainer Agent download for ${ARCH} (not supported)"
-fi
-
-# Download CoreDNS
+# Download CoreDNS (always embedded)
 echo "Downloading CoreDNS ${COREDNS_VERSION}..."
 COREDNS_IMAGE="coredns/coredns:${COREDNS_VERSION}"
 if ! crane pull --platform ${OS}/${ARCH} ${COREDNS_IMAGE} internal/core/embedded/bin/images/coredns.tar; then
     echo "Error pulling CoreDNS image."
     exit 1
 fi
-# Compress it to save space
 if ! gzip -f internal/core/embedded/bin/images/coredns.tar; then
     echo "Error compressing CoreDNS image."
     exit 1
 fi
 echo "CoreDNS image saved successfully."
 
-# Download Local Path Provisioner
-echo "Downloading Local Path Provisioner ${LOCAL_PATH_PROVISIONER_VERSION}..."
-LOCAL_PATH_PROVISIONER_IMAGE="rancher/local-path-provisioner:${LOCAL_PATH_PROVISIONER_VERSION}"
-if ! crane pull --platform ${OS}/${ARCH} ${LOCAL_PATH_PROVISIONER_IMAGE} internal/core/embedded/bin/images/local-path-provisioner.tar; then
-    echo "Error pulling Local Path Provisioner image."
-    exit 1
+# Download optional images only for offline builds
+if [ "${OFFLINE}" = "true" ]; then
+    # Download Portainer Agent (skip for riscv64 as it's not supported)
+    if [ "${ARCH}" != "riscv64" ]; then
+        echo "Downloading Portainer Agent ${PORTAINER_AGENT_VERSION}..."
+        PORTAINER_IMAGE="portainer/agent:${PORTAINER_AGENT_VERSION}"
+        if ! crane pull --platform ${OS}/${ARCH} ${PORTAINER_IMAGE} internal/core/embedded/bin/images/portainer-agent.tar; then
+            echo "Error pulling Portainer Agent image."
+            exit 1
+        fi
+        if ! gzip -f internal/core/embedded/bin/images/portainer-agent.tar; then
+            echo "Error compressing Portainer Agent image."
+            exit 1
+        fi
+        echo "Portainer Agent image saved and compressed successfully."
+    else
+        echo "Skipping Portainer Agent download for ${ARCH} (not supported)"
+    fi
+
+    # Download Local Path Provisioner
+    echo "Downloading Local Path Provisioner ${LOCAL_PATH_PROVISIONER_VERSION}..."
+    LOCAL_PATH_PROVISIONER_IMAGE="rancher/local-path-provisioner:${LOCAL_PATH_PROVISIONER_VERSION}"
+    if ! crane pull --platform ${OS}/${ARCH} ${LOCAL_PATH_PROVISIONER_IMAGE} internal/core/embedded/bin/images/local-path-provisioner.tar; then
+        echo "Error pulling Local Path Provisioner image."
+        exit 1
+    fi
+    if ! gzip -f internal/core/embedded/bin/images/local-path-provisioner.tar; then
+        echo "Error compressing Local Path Provisioner image."
+        exit 1
+    fi
+    echo "Local Path Provisioner image saved successfully."
+else
+    echo "Skipping optional image downloads (online build). Images will be pulled at runtime."
 fi
-# Compress it to save space
-if ! gzip -f internal/core/embedded/bin/images/local-path-provisioner.tar; then
-    echo "Error compressing Local Path Provisioner image."
-    exit 1
-fi
-echo "Local Path Provisioner image saved successfully."
 
 # Download Kubernetes pause image
 echo "Downloading Portainer pause image..."

--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -367,8 +367,8 @@ func (s *kubesolo) bootstrap() {
 		ContainerdCNIConfigDir:  filepath.Join(basePath, types.DefaultContainerdDir, "cni", "conf"),
 		ContainerdCNIConfigFile: filepath.Join(basePath, types.DefaultContainerdDir, "cni", "conf", types.DefaultCNIConfigName),
 
-		// Runc binary
-		RuncBinaryFile: filepath.Join(basePath, types.DefaultContainerdDir, "runc"),
+		// Crun binary
+		CrunBinaryFile: filepath.Join(basePath, types.DefaultContainerdDir, "crun"),
 
 		// Kubelet paths
 		KubeletDir:            filepath.Join(basePath, types.DefaultKubeletDir),

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/containerd/containerd/v2 v2.1.5
 	github.com/k3s-io/kine v0.14.6
+	github.com/klauspost/compress v1.18.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.9.1
@@ -115,7 +116,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/karrick/godirwalk v1.17.0 // indirect
-	github.com/klauspost/compress v1.18.4 // indirect
+	github.com/klauspost/compress v1.18.4
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/libopenstorage/openstorage v1.0.0 // indirect
 	github.com/lithammer/dedent v1.1.0 // indirect

--- a/internal/core/embedded/embedded.go
+++ b/internal/core/embedded/embedded.go
@@ -10,32 +10,26 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-//go:embed bin/containerd/bin/containerd-shim-runc-v2
+//go:embed bin/containerd/bin/containerd-shim-runc-v2.zst
 var containerdShimBinary []byte
 
-//go:embed bin/runc
-var runcBinary []byte
+//go:embed bin/crun.zst
+var crunBinary []byte
 
-//go:embed bin/cni/bridge
+//go:embed bin/cni/bridge.zst
 var cniPluginBridge []byte
 
-//go:embed bin/cni/host-local
+//go:embed bin/cni/host-local.zst
 var cniPluginHostLocal []byte
 
-//go:embed bin/cni/portmap
+//go:embed bin/cni/portmap.zst
 var cniPluginPortmap []byte
 
-//go:embed bin/cni/loopback
+//go:embed bin/cni/loopback.zst
 var cniPluginLoopback []byte
 
 //go:embed bin/images/coredns.tar.gz
 var corednsImageFile []byte
-
-//go:embed bin/images/portainer-agent.tar.gz
-var portainerAgentImageFile []byte
-
-//go:embed bin/images/local-path-provisioner.tar.gz
-var localPathProvisionerImageFile []byte
 
 //go:embed bin/images/pause.tar.gz
 var sandboxImageFile []byte

--- a/internal/core/embedded/embedded_images_offline.go
+++ b/internal/core/embedded/embedded_images_offline.go
@@ -1,0 +1,11 @@
+//go:build offline && !riscv64
+
+package embedded
+
+import _ "embed"
+
+//go:embed bin/images/portainer-agent.tar.gz
+var portainerAgentImageFile []byte
+
+//go:embed bin/images/local-path-provisioner.tar.gz
+var localPathProvisionerImageFile []byte

--- a/internal/core/embedded/embedded_images_offline_riscv64.go
+++ b/internal/core/embedded/embedded_images_offline_riscv64.go
@@ -1,0 +1,11 @@
+//go:build offline && riscv64
+
+package embedded
+
+import _ "embed"
+
+// portainerAgentImageFile is empty for riscv64 as portainer-agent is not available for this architecture.
+var portainerAgentImageFile []byte
+
+//go:embed bin/images/local-path-provisioner.tar.gz
+var localPathProvisionerImageFile []byte

--- a/internal/core/embedded/embedded_images_online.go
+++ b/internal/core/embedded/embedded_images_online.go
@@ -1,0 +1,11 @@
+//go:build !offline
+
+package embedded
+
+// portainerAgentImageFile is not embedded in the online build variant.
+// The image will be pulled from the registry at runtime.
+var portainerAgentImageFile []byte
+
+// localPathProvisionerImageFile is not embedded in the online build variant.
+// The image will be pulled from the registry at runtime.
+var localPathProvisionerImageFile []byte

--- a/internal/core/embedded/embedded_riscv64.go
+++ b/internal/core/embedded/embedded_riscv64.go
@@ -10,32 +10,26 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-//go:embed bin/containerd/bin/containerd-shim-runc-v2
+//go:embed bin/containerd/bin/containerd-shim-runc-v2.zst
 var containerdShimBinary []byte
 
-//go:embed bin/runc
-var runcBinary []byte
+//go:embed bin/crun.zst
+var crunBinary []byte
 
-//go:embed bin/cni/bridge
+//go:embed bin/cni/bridge.zst
 var cniPluginBridge []byte
 
-//go:embed bin/cni/host-local
+//go:embed bin/cni/host-local.zst
 var cniPluginHostLocal []byte
 
-//go:embed bin/cni/portmap
+//go:embed bin/cni/portmap.zst
 var cniPluginPortmap []byte
 
-//go:embed bin/cni/loopback
+//go:embed bin/cni/loopback.zst
 var cniPluginLoopback []byte
 
 //go:embed bin/images/coredns.tar.gz
 var corednsImageFile []byte
-
-// portainerAgentImageFile is empty for riscv64 as portainer-agent is not available for this architecture
-var portainerAgentImageFile []byte
-
-//go:embed bin/images/local-path-provisioner.tar.gz
-var localPathProvisionerImageFile []byte
 
 //go:embed bin/images/pause.tar.gz
 var sandboxImageFile []byte

--- a/internal/core/embedded/load.go
+++ b/internal/core/embedded/load.go
@@ -24,7 +24,7 @@ func loadContainerdComponents(embedded types.Embedded) error {
 		name        string
 	}{
 		{containerdShimBinary, embedded.ContainerdShimBinaryFile, "containerd-shim-runc-v2"},
-		{runcBinary, embedded.RuncBinaryFile, "runc"},
+		{crunBinary, embedded.CrunBinaryFile, "crun"},
 	}
 
 	for _, binary := range binaries {

--- a/internal/runtime/filesystem/binary.go
+++ b/internal/runtime/filesystem/binary.go
@@ -1,18 +1,33 @@
 package filesystem
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
+
+	"github.com/klauspost/compress/zstd"
 )
 
-// ExtractBinary extracts and installs a binary
+// ExtractBinary extracts a zstd-compressed binary and installs it to destFile.
 // TODO: get the SHA of each binary and compare it to the expected SHA
-func ExtractBinary(binary []byte, destFile string) error {
+func ExtractBinary(compressed []byte, destFile string) error {
 	if _, err := os.Stat(destFile); err == nil {
 		return nil
 	}
 
-	if err := os.WriteFile(destFile, binary, 0755); err != nil {
+	decoder, err := zstd.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return fmt.Errorf("failed to create zstd decoder for %s: %v", destFile, err)
+	}
+	defer decoder.Close()
+
+	decompressed, err := io.ReadAll(decoder)
+	if err != nil {
+		return fmt.Errorf("failed to decompress %s: %v", destFile, err)
+	}
+
+	if err := os.WriteFile(destFile, decompressed, 0755); err != nil {
 		return fmt.Errorf("failed to write %s binary: %v", destFile, err)
 	}
 

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -10,6 +10,8 @@ import (
 )
 
 // isCgroupV2 returns true if the host uses the cgroupv2 unified hierarchy.
+// When true, crun must use the systemd cgroup driver (SystemdCgroup=true)
+// instead of the cgroupfs driver which generates cgroupv1-style paths.
 func isCgroupV2() bool {
 	_, err := os.Stat("/sys/fs/cgroup/cgroup.controllers")
 	return err == nil
@@ -109,11 +111,11 @@ func (s *service) generateContainerdConfig() map[string]any {
 				"drain_exec_sync_io_timeout":             "0s",
 				"ignore_deprecation_warnings":            []string{},
 				"containerd": map[string]any{
-					"default_runtime_name":              "runc",
+					"default_runtime_name":              "crun",
 					"ignore_blockio_not_enabled_errors": false,
 					"ignore_rdt_not_enabled_errors":     false,
 					"runtimes": map[string]any{
-						"runc": map[string]any{
+						"crun": map[string]any{
 							"runtime_type":                    "io.containerd.runc.v2",
 							"runtime_path":                    s.containerdShimBinaryFile,
 							"pod_annotations":                 []string{},
@@ -127,7 +129,7 @@ func (s *service) generateContainerdConfig() map[string]any {
 							"sandboxer":         "podsandbox",
 							"io_type":           "",
 							"options": map[string]any{
-								"BinaryName":    s.runcBinaryFile,
+								"BinaryName":    s.crunBinaryFile,
 								"SystemdCgroup": useSystemdCgroup(),
 							},
 						},

--- a/pkg/runtime/containerd/image.go
+++ b/pkg/runtime/containerd/image.go
@@ -13,22 +13,22 @@ import (
 )
 
 // importImages imports the images into the containerd registry
-func (s *service) importImages(ctx context.Context, client *client.Client, isPortainerAgent bool) error {
-	context := namespaces.WithNamespace(ctx, types.DefaultK8sNamespace)
-	if err := s.importImage(context, client, s.corednsImageFile); err != nil {
+func (s *service) importImages(ctx context.Context, c *client.Client, isPortainerAgent bool) error {
+	nsCtx := namespaces.WithNamespace(ctx, types.DefaultK8sNamespace)
+	if err := s.importImage(nsCtx, c, s.corednsImageFile, types.DefaultCoreDNSImage); err != nil {
 		return err
 	}
 
-	if err := s.importImage(context, client, s.sandboxImageFile); err != nil {
+	if err := s.importImage(nsCtx, c, s.sandboxImageFile, types.DefaultSandboxImage); err != nil {
 		return err
 	}
 
-	if err := s.importImage(context, client, s.localPathProvisionerImageFile); err != nil {
+	if err := s.importImage(nsCtx, c, s.localPathProvisionerImageFile, types.DefaultLocalPathProvisionerImage); err != nil {
 		return err
 	}
 
 	if isPortainerAgent {
-		if err := s.importImage(context, client, s.portainerAgentImageFile); err != nil {
+		if err := s.importImage(nsCtx, c, s.portainerAgentImageFile, types.DefaultPortainerAgentImage); err != nil {
 			return err
 		}
 	}
@@ -36,34 +36,35 @@ func (s *service) importImages(ctx context.Context, client *client.Client, isPor
 	return nil
 }
 
-// importImage imports an image into the containerd registry
-func (s *service) importImage(ctx context.Context, client *client.Client, image string) error {
-	log.Debug().Str("component", "containerd").Str("image", image).Msg("importing image")
+// importImage imports an image into the containerd registry from a local file.
+// If the local file is not found (not embedded), it falls back to pulling from the registry.
+func (s *service) importImage(ctx context.Context, c *client.Client, imageFile string, imageRef string) error {
+	log.Debug().Str("component", "containerd").Str("image", imageRef).Msg("loading image")
 
-	if _, err := os.Stat(image); err != nil {
-		if os.IsNotExist(err) {
-			log.Warn().Str("component", "containerd").Str("image", image).Msg("image file not found, skipping import (likely not embedded for this architecture)")
-			return nil
-		} else {
-			return fmt.Errorf("failed to check image file %s: %v", image, err)
+	info, err := os.Stat(imageFile)
+	if err != nil || info.Size() == 0 {
+		log.Info().Str("component", "containerd").Str("image", imageRef).Msg("embedded image not available, pulling from registry")
+		if _, pullErr := c.Pull(ctx, imageRef, client.WithPullUnpack); pullErr != nil {
+			return fmt.Errorf("failed to pull image %s: %v", imageRef, pullErr)
 		}
+		return nil
 	}
 
-	log.Debug().Str("component", "containerd").Str("image", image).Msg("importing image")
-	imageFile, err := os.Open(image)
+	log.Debug().Str("component", "containerd").Str("image", imageRef).Msg("importing embedded image")
+	f, err := os.Open(imageFile)
 	if err != nil {
 		return fmt.Errorf("failed to open image file: %v", err)
 	}
-	defer imageFile.Close()
+	defer f.Close()
 
-	gzipReader, err := gzip.NewReader(imageFile)
+	gzipReader, err := gzip.NewReader(f)
 	if err != nil {
 		return err
 	}
 	defer gzipReader.Close()
 
-	if _, err := client.Import(ctx, gzipReader); err != nil {
-		return fmt.Errorf("failed to import image: %v", err)
+	if _, err := c.Import(ctx, gzipReader); err != nil {
+		return fmt.Errorf("failed to import image %s: %v", imageRef, err)
 	}
 
 	return nil

--- a/pkg/runtime/containerd/service.go
+++ b/pkg/runtime/containerd/service.go
@@ -21,7 +21,7 @@ type service struct {
 	containerdSocketFile          string
 	containerdCNIPluginsDir       string
 	containerdRegistryConfigDir   string
-	runcBinaryFile                string
+	crunBinaryFile                string
 	containerdShimBinaryFile      string
 	portainerAgentImageFile       string
 	corednsImageFile              string
@@ -44,7 +44,7 @@ func NewService(ctx context.Context, cancel context.CancelFunc, containerdReady 
 		containerdSocketFile:          embedded.ContainerdSocketFile,
 		containerdCNIPluginsDir:       embedded.ContainerdCNIPluginsDir,
 		containerdRegistryConfigDir:   embedded.ContainerdRegistryConfigDir,
-		runcBinaryFile:                embedded.RuncBinaryFile,
+		crunBinaryFile:                embedded.CrunBinaryFile,
 		containerdShimBinaryFile:      embedded.ContainerdShimBinaryFile,
 		portainerAgentImageFile:       embedded.PortainerAgentImageFile,
 		corednsImageFile:              embedded.CorednsImageFile,

--- a/types/types.go
+++ b/types/types.go
@@ -89,8 +89,8 @@ type Embedded struct {
 	ContainerdCNIConfigDir  string
 	ContainerdCNIConfigFile string
 
-	// Runc binary
-	RuncBinaryFile string
+	// Crun binary
+	CrunBinaryFile string
 
 	// Kubelet directories
 	KubeletDir            string


### PR DESCRIPTION
## Description

Reduces KubeSolo binary size by ~160–180 MB for the default (online) build variant through three changes:

### Phase 1: Replace runc with crun

Replace runc (~10 MB) with [crun](https://github.com/containers/crun) (~1 MB) as the OCI runtime. crun is a lightweight C-based runtime that is fully OCI-compliant and used as the default in Podman/Buildah. It supports cgroupv2 natively.

**Note:** crun does not publish pre-built 32-bit ARM (`armhf`) binaries. The `download-deps.sh` script will fail early with a clear error for `GOARCH=arm`.

### Phase 2: zstd-compress embedded binaries

Compress `containerd-shim-runc-v2`, `crun`, and CNI plugin binaries with `zstd -19` before `go:embed`. Binaries are decompressed at extraction time using `github.com/klauspost/compress/zstd` (already an indirect dependency, promoted to direct).

### Phase 3: Online/offline build variants via build tags

Split into two build modes:

| Variant | Build Tag | Embedded Images | Runtime Behavior |
|---------|-----------|----------------|------------------|
| **Online** (default) | none | CoreDNS + pause only | Portainer Agent + local-path-provisioner pulled via `client.Pull()` |
| **Offline** | `-tags offline` | All images | Air-gapped deployments, no network needed |

The `importImage()` function now falls back to `client.Pull()` when an embedded image file is empty or missing, making the online variant seamless.

### Build Commands

```bash
# Online build (default, ~160-180 MB smaller)
make build GOOS=linux GOARCH=amd64

# Offline build (all images embedded, air-gapped)
make build-offline GOOS=linux GOARCH=amd64

# Download deps for offline
make deps-offline
```

### Files Changed

| File | Change |
|------|--------|
| `Makefile` | Add `build-offline` and `deps-offline` targets |
| `build/download-deps.sh` | crun download, zstd compression, `--offline` flag |
| `cmd/kubesolo/main.go` | `RuncBinaryFile` → `CrunBinaryFile` |
| `go.mod` | Promote `klauspost/compress` to direct dependency |
| `internal/core/embedded/embedded.go` | `.zst` suffixes, remove always-embedded optional images |
| `internal/core/embedded/embedded_riscv64.go` | Same `.zst` changes for riscv64 |
| `internal/core/embedded/embedded_images_offline.go` | **New** embed optional images with `//go:build offline` |
| `internal/core/embedded/embedded_images_offline_riscv64.go` | **New** offline riscv64 (no portainer-agent) |
| `internal/core/embedded/embedded_images_online.go` | **New** empty vars for online build |
| `internal/core/embedded/load.go` | `runcBinary` → `crunBinary` |
| `internal/runtime/filesystem/binary.go` | zstd decompression in `ExtractBinary()` |
| `pkg/runtime/containerd/config.go` | Runtime name `runc` → `crun`, cgroupv2 detection |
| `pkg/runtime/containerd/image.go` | Fallback to `client.Pull()` for missing images |
| `pkg/runtime/containerd/service.go` | `runcBinaryFile` → `crunBinaryFile` |
| `types/types.go` | `RuncBinaryFile` → `CrunBinaryFile` |

### Testing

- Online build: verified CoreDNS/pause load from embedded, portainer-agent/local-path-provisioner pulled at runtime
- Offline build: verified all images load from embedded tar.gz files
- Verified zstd decompression produces identical binaries to originals
- Tested on amd64 and arm64