### PR TITLE
perf(webhook): pre-compute patch objects to eliminate per-request allocations

### DIFF
--- a/pkg/kubernetes/webhook/patch.go
+++ b/pkg/kubernetes/webhook/patch.go
@@ -1,8 +1,6 @@
 package webhook
 
 import (
-	"encoding/json"
-
 	"github.com/rs/zerolog/log"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,16 +14,7 @@ func (w *Service) createNodeNamePatch(pod corev1.Pod) []map[string]any {
 		Str("node", w.nodeName).
 		Msg("setting node name for pod")
 
-	// Use pre-computed patch to reduce CPU usage
-	var patch []map[string]any
-	if err := json.Unmarshal(w.nodeNamePatch, &patch); err != nil {
-		log.Error().Err(err).Str("component", "webhook").
-			Str("pod", pod.Name).
-			Str("namespace", pod.Namespace).
-			Msg("failed to unmarshal nodeNamePatch")
-		return []map[string]any{}
-	}
-	return patch
+	return w.nodeNamePatchObj
 }
 
 // createNodeSelectorPatch creates a patch to set the node selector for the job
@@ -36,13 +25,5 @@ func (w *Service) createNodeSelectorPatch(job batchv1.Job) []map[string]any {
 		Str("node", w.nodeName).
 		Msg("setting node selector for job")
 
-	var patch []map[string]any
-	if err := json.Unmarshal(w.nodeSelectorPatch, &patch); err != nil {
-		log.Error().Err(err).Str("component", "webhook").
-			Str("job", job.Name).
-			Str("namespace", job.Namespace).
-			Msg("failed to unmarshal nodeSelectorPatch")
-		return []map[string]any{}
-	}
-	return patch
+	return w.nodeSelectorPatchObj
 }

--- a/pkg/kubernetes/webhook/service.go
+++ b/pkg/kubernetes/webhook/service.go
@@ -28,6 +28,8 @@ type Service struct {
 	hostsEntries            map[string]string
 	nodeNamePatch           []byte
 	nodeSelectorPatch       []byte
+	nodeNamePatchObj        []map[string]any
+	nodeSelectorPatchObj    []map[string]any
 	pvcAnnotationPatch      []map[string]any
 	loadBalancerStatusPatch []byte
 	requestMutex            sync.Mutex
@@ -39,15 +41,16 @@ type Service struct {
 
 // NewService creates a new webhook server
 func NewService(nodeName, nodeIP, pkiPath, adminKubeconfig string, loadBalancer bool) *Service {
-	nodeNamePatch, _ := json.Marshal([]map[string]any{
+	// define struct form first, marshal from it — no round trip
+	nodeNamePatchObj := []map[string]any{
 		{
 			"op":    "add",
 			"path":  "/spec/nodeName",
 			"value": nodeName,
 		},
-	})
+	}
 
-	nodeSelectorPatch, _ := json.Marshal([]map[string]any{
+	nodeSelectorPatchObj := []map[string]any{
 		{
 			"op":   "add",
 			"path": "/spec/template/spec/nodeSelector",
@@ -55,7 +58,10 @@ func NewService(nodeName, nodeIP, pkiPath, adminKubeconfig string, loadBalancer 
 				"kubernetes.io/hostname": nodeName,
 			},
 		},
-	})
+	}
+
+	nodeNamePatch, _ := json.Marshal(nodeNamePatchObj)
+	nodeSelectorPatch, _ := json.Marshal(nodeSelectorPatchObj)
 
 	pvcAnnotationPatch := []map[string]any{
 		{
@@ -87,6 +93,8 @@ func NewService(nodeName, nodeIP, pkiPath, adminKubeconfig string, loadBalancer 
 		hostsEntries:            make(map[string]string),
 		nodeNamePatch:           nodeNamePatch,
 		nodeSelectorPatch:       nodeSelectorPatch,
+		nodeNamePatchObj:        nodeNamePatchObj,
+		nodeSelectorPatchObj:    nodeSelectorPatchObj,
 		pvcAnnotationPatch:      pvcAnnotationPatch,
 		loadBalancerStatusPatch: loadBalancerStatusPatch,
 		loadBalancer:            loadBalancer,


### PR DESCRIPTION
## How I found this

While going through the webhook code I noticed something interesting in `patch.go`. There was a comment that read:

```go
// Use pre-computed patch to reduce CPU usage
var patch []map[string]any
if err := json.Unmarshal(w.nodeNamePatch, &patch); err != nil {
```

The intent here was clearly thoughtful. `NewService` already marshals the patch data once into `[]byte` at startup so the JSON encoding work is not repeated.

But `patch.go` was still calling `json.Unmarshal` on every single webhook request to get back the `[]map[string]any` form. So the actual flow was:

- encode at startup into `[]byte`
- decode back on every pod creation into `[]map[string]any`
- use the original `[]byte` for the HTTP response anyway

The decoded struct existed only so `createAdmissionResponse` could read `patches[0]["path"]` to decide which fast path to take. After that it was thrown away and the original bytes were used for the response. The decode was doing 20 heap allocations and 704 bytes of work on every pod creation for no lasting benefit.

## Why the patch never changes

The node name comes from `os.Hostname()` once in `GetHostname()` when kubesolo starts. It is passed into `NewService` and stored as `w.nodeName`. Nothing updates it after that. So the patch content is completely fixed:

```json
[{"op": "add", "path": "/spec/nodeName", "value": "kubesolo-node"}]
```

Same bytes. Same struct. Every pod. Every job. Every time.

## What changed

Instead of defining `[]byte` first and decoding from it on demand, the `[]map[string]any` form is now defined first and `[]byte` is derived from it once. Both are stored in the struct. No decoding ever happens at request time.

```go
// before
nodeNamePatch, _ := json.Marshal([]map[string]any{...})
// then in patch.go on every request:
json.Unmarshal(w.nodeNamePatch, &patch)

// after
nodeNamePatchObj := []map[string]any{
    {"op": "add", "path": "/spec/nodeName", "value": nodeName},
}
nodeNamePatch, _ := json.Marshal(nodeNamePatchObj)
// both stored, nothing decoded at request time
```

## How I verified this

Unmarshal was definitely running every call.

On concurrency: `createAdmissionResponse` only reads `patches[0]["path"]`, never writes to it. Read-only access from multiple goroutines is safe in Go without any locks.

## Benchmark results

```
BenchmarkOriginalNodeNamePatch        551146   1873 ns/op   704 B/op   20 allocs/op
BenchmarkOptimizedNodeNamePatch   1000000000      0.63 ns/op     0 B/op    0 allocs/op

BenchmarkOriginalNodeSelectorPatch    430765   2742 ns/op  1112 B/op   24 allocs/op
BenchmarkOptimizedNodeSelectorPatch 1000000000      0.33 ns/op     0 B/op    0 allocs/op
```

Real-world burst test, 1000 bursts of 25 objects (20 pods + 5 jobs matching `maxPods: 20`), each run independently to avoid cache bias:

```
TestFeelTheImpactOriginal    57.58ms
TestFeelTheImpactOptimized    0.03ms
```

You can reproduce this by running:

```bash
go test ./pkg/kubernetes/webhook/ -run "TestPatchValuesIdentical" -bench=Benchmark -benchmem
```

## Why this matters

The impact is most visible at startup when the webhook is hit in rapid succession by all pods being created simultaneously.

## Testing files for benchmark

```go
package webhook

import (
	"encoding/json"
	"testing"

	batchv1 "k8s.io/api/batch/v1"
	corev1 "k8s.io/api/core/v1"
)

// TestPatchValuesIdentical proves our pre-computed patches
// produce byte-for-byte identical output to the original unmarshal approach
func TestPatchValuesIdentical(t *testing.T) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)

	// --- nodeNamePatch ---
	pod := corev1.Pod{}
	pod.Name = "test-pod"
	pod.Namespace = "default"

	// original approach: unmarshal from []byte
	var originalNodePatch []map[string]any
	json.Unmarshal(svc.nodeNamePatch, &originalNodePatch)

	// our approach: pre-computed
	ourNodePatch := svc.createNodeNamePatch(pod)

	originalBytes, _ := json.Marshal(originalNodePatch)
	ourBytes, _ := json.Marshal(ourNodePatch)

	if string(originalBytes) != string(ourBytes) {
		t.Errorf("nodeNamePatch mismatch:\n  original: %s\n  ours:     %s", originalBytes, ourBytes)
	} else {
		t.Logf("nodeNamePatch IDENTICAL: %s", ourBytes)
	}

	// --- nodeSelectorPatch ---
	job := batchv1.Job{}
	job.Name = "test-job"
	job.Namespace = "default"

	var originalSelectorPatch []map[string]any
	json.Unmarshal(svc.nodeSelectorPatch, &originalSelectorPatch)

	ourSelectorPatch := svc.createNodeSelectorPatch(job)

	originalBytes, _ = json.Marshal(originalSelectorPatch)
	ourBytes, _ = json.Marshal(ourSelectorPatch)

	if string(originalBytes) != string(ourBytes) {
		t.Errorf("nodeSelectorPatch mismatch:\n  original: %s\n  ours:     %s", originalBytes, ourBytes)
	} else {
		t.Logf("nodeSelectorPatch IDENTICAL: %s", ourBytes)
	}
}

// BenchmarkOriginalNodeNamePatch simulates the original unmarshal-every-call approach
func BenchmarkOriginalNodeNamePatch(b *testing.B) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var patch []map[string]any
		json.Unmarshal(svc.nodeNamePatch, &patch)
		_ = patch
	}
}

// BenchmarkOptimizedNodeNamePatch measures our pre-computed approach
func BenchmarkOptimizedNodeNamePatch(b *testing.B) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	pod := corev1.Pod{}
	pod.Name = "test-pod"
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = svc.createNodeNamePatch(pod)
	}
}

// BenchmarkOriginalNodeSelectorPatch simulates the original unmarshal-every-call approach
func BenchmarkOriginalNodeSelectorPatch(b *testing.B) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		var patch []map[string]any
		json.Unmarshal(svc.nodeSelectorPatch, &patch)
		_ = patch
	}
}

// BenchmarkOptimizedNodeSelectorPatch measures our pre-computed approach
func BenchmarkOptimizedNodeSelectorPatch(b *testing.B) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	job := batchv1.Job{}
	job.Name = "test-job"
	b.ReportAllocs()
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_ = svc.createNodeSelectorPatch(job)
	}
}

```

```bash
go test ./pkg/kubernetes/webhook/ -run "TestPatchValuesIdentical" -bench=Benchmark -benchmem
```

### testing for pod and job time creation
```go
package webhook

import (
	"encoding/json"
	"fmt"
	"testing"
	"time"

	batchv1 "k8s.io/api/batch/v1"
	corev1 "k8s.io/api/core/v1"
)

func makePods(n int) []corev1.Pod {
	pods := make([]corev1.Pod, n)
	for i := range pods {
		pods[i].Name = fmt.Sprintf("pod-%d", i)
		pods[i].Namespace = "default"
	}
	return pods
}

func makeJobs(n int) []batchv1.Job {
	jobs := make([]batchv1.Job, n)
	for i := range jobs {
		jobs[i].Name = fmt.Sprintf("job-%d", i)
		jobs[i].Namespace = "default"
	}
	return jobs
}

func TestFeelTheImpactOriginal(t *testing.T) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	pods := makePods(20)
	jobs := makeJobs(5)

	start := time.Now()
	for i := 0; i < 1000; i++ {
		for range pods {
			var patch []map[string]any
			json.Unmarshal(svc.nodeNamePatch, &patch)
		}
		for range jobs {
			var patch []map[string]any
			json.Unmarshal(svc.nodeSelectorPatch, &patch)
		}
	}
	t.Logf("original (1000 bursts x 25 objects): %v", time.Since(start))
}

func TestFeelTheImpactOptimized(t *testing.T) {
	svc := NewService("kubesolo-node", "192.168.1.1", "/tmp/pki", "/tmp/kubeconfig", false)
	pods := makePods(20)
	jobs := makeJobs(5)

	start := time.Now()
	for i := 0; i < 1000; i++ {
		for _, pod := range pods {
			_ = svc.createNodeNamePatch(pod)
		}
		for _, job := range jobs {
			_ = svc.createNodeSelectorPatch(job)
		}
	}
	t.Logf("optimized (1000 bursts x 25 objects): %v", time.Since(start))
}
```
```bash
go test ./pkg/kubernetes/webhook/ -run TestFeelTheImpact -v 2>/dev/null
```
@stevensbkang thoughts on this!