### PR TITLE
feat(registry): adding support for registry configuration via hosts.toml

### DIFF
--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -359,7 +359,7 @@ func (s *kubesolo) bootstrap() {
 		ContainerdConfigFile:     filepath.Join(basePath, types.DefaultContainerdDir, "config.toml"),
 		ContainerdRootDir:           filepath.Join(basePath, types.DefaultContainerdDir, "root"),
 		ContainerdStateDir:          filepath.Join(basePath, types.DefaultContainerdDir, "state"),
-		ContainerdRegistryConfigDir: filepath.Join(basePath, types.DefaultContainerdDir, types.DefaultContainerdRegistryDir),
+		ContainerdRegistryConfigDir: filepath.Join(basePath, types.DefaultContainerdDir, "registry"),
 
 		// CNI paths
 		ContainerdCNIDir:        filepath.Join(basePath, types.DefaultContainerdDir, "cni"),

--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -357,8 +357,9 @@ func (s *kubesolo) bootstrap() {
 		ContainerdImagesDir:      filepath.Join(basePath, types.DefaultContainerdDir, "images"),
 		ContainerdShimBinaryFile: filepath.Join(basePath, types.DefaultContainerdDir, "containerd-shim-runc-v2"),
 		ContainerdConfigFile:     filepath.Join(basePath, types.DefaultContainerdDir, "config.toml"),
-		ContainerdRootDir:        filepath.Join(basePath, types.DefaultContainerdDir, "root"),
-		ContainerdStateDir:       filepath.Join(basePath, types.DefaultContainerdDir, "state"),
+		ContainerdRootDir:           filepath.Join(basePath, types.DefaultContainerdDir, "root"),
+		ContainerdStateDir:          filepath.Join(basePath, types.DefaultContainerdDir, "state"),
+		ContainerdRegistryConfigDir: filepath.Join(basePath, types.DefaultContainerdDir, types.DefaultContainerdRegistryDir),
 
 		// CNI paths
 		ContainerdCNIDir:        filepath.Join(basePath, types.DefaultContainerdDir, "cni"),

--- a/docs/configuration/registry.md
+++ b/docs/configuration/registry.md
@@ -1,0 +1,172 @@
+# Registry Configuration
+
+KubeSolo supports container registry configuration — including mirrors, pull-through proxy caches, private registries, and custom TLS — as an advanced capability using containerd's [`hosts.toml`](https://github.com/containerd/containerd/blob/main/docs/hosts.md) mechanism.
+
+No flags or code changes are required. Users who need registry configuration create the appropriate files in a well-known directory; users who do not are unaffected.
+
+---
+
+## How It Works
+
+At startup, KubeSolo sets containerd's `config_path` to:
+
+```
+/var/lib/kubesolo/containerd/registry
+```
+
+This tells containerd to look in that directory for per-registry configuration files at image pull time. When the directory is absent or empty, containerd behaves exactly as it does by default.
+
+To configure a registry, create a subdirectory named after the registry hostname and place a `hosts.toml` file inside it:
+
+```
+/var/lib/kubesolo/containerd/registry/
+└── <registry-hostname>/
+    └── hosts.toml
+```
+
+containerd reads `hosts.toml` files at pull time — **no restart is needed** after creating or modifying them. A KubeSolo restart is only required the first time, to pick up the `config_path` setting in the generated containerd config.
+
+> **Note:** Always use fully-qualified image references (e.g. `docker.io/library/nginx:alpine`) so containerd can unambiguously map the pull to the correct `hosts.toml`.
+
+---
+
+## Scenarios
+
+### Simple mirror for Docker Hub
+
+```bash
+mkdir -p /var/lib/kubesolo/containerd/registry/docker.io
+```
+
+```toml
+# /var/lib/kubesolo/containerd/registry/docker.io/hosts.toml
+server = "https://registry-1.docker.io"
+
+[host."https://mirror.corp.internal"]
+  capabilities = ["pull", "resolve"]
+```
+
+If the mirror does not have the image, containerd falls back to `registry-1.docker.io`.
+
+---
+
+### Harbor proxy cache
+
+Harbor's registry API is project-scoped — the project name sits inside the API path after `/v2/`. The mirror URL must include this prefix, and `override_path = true` must be set so containerd does not prepend its own `/v2/`.
+
+```bash
+mkdir -p /var/lib/kubesolo/containerd/registry/docker.io
+```
+
+```toml
+# /var/lib/kubesolo/containerd/registry/docker.io/hosts.toml
+server = "https://registry-1.docker.io"
+
+[host."https://harbor.corp.internal/v2/docker.io"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+```
+
+For a Harbor instance with a private CA:
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://harbor.corp.internal/v2/docker.io"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+  ca = "/etc/ssl/certs/harbor-ca.crt"
+```
+
+For a private Harbor project requiring authentication:
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://harbor.corp.internal/v2/docker.io"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+  [host."https://harbor.corp.internal/v2/docker.io".header]
+    Authorization = ["Basic <base64(robot$account:token)>"]
+```
+
+Generate the Base64 value with:
+
+```bash
+echo -n "robot\$account:token" | base64
+```
+
+---
+
+### Multiple registries
+
+Create a separate subdirectory for each upstream registry:
+
+```
+/var/lib/kubesolo/containerd/registry/
+├── docker.io/
+│   └── hosts.toml
+├── ghcr.io/
+│   └── hosts.toml
+└── quay.io/
+    └── hosts.toml
+```
+
+```toml
+# ghcr.io/hosts.toml
+server = "https://ghcr.io"
+
+[host."https://harbor.corp.internal/v2/ghcr.io"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+```
+
+---
+
+### Air-gapped environment
+
+Use the special `_default` directory as a catch-all for any registry that does not have its own entry:
+
+```bash
+mkdir -p /var/lib/kubesolo/containerd/registry/_default
+```
+
+```toml
+# /var/lib/kubesolo/containerd/registry/_default/hosts.toml
+[host."https://airgap-registry.corp.internal"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/ssl/certs/corp-ca.crt"
+```
+
+A registry-specific `hosts.toml` always takes precedence over `_default`.
+
+---
+
+### Local registry without TLS
+
+```bash
+mkdir -p /var/lib/kubesolo/containerd/registry/localhost:5000
+```
+
+```toml
+# /var/lib/kubesolo/containerd/registry/localhost:5000/hosts.toml
+server = "http://localhost:5000"
+
+[host."http://localhost:5000"]
+  capabilities = ["pull", "resolve", "push"]
+  skip_verify = true
+```
+
+---
+
+## Verifying
+
+After placing your `hosts.toml` files, run a test pod using an image not already cached locally and confirm the pull appears in your mirror or proxy cache logs:
+
+```bash
+kubectl run registry-test --image=docker.io/library/nginx:alpine --restart=Never \
+  --kubeconfig=/var/lib/kubesolo/pki/admin/admin.kubeconfig
+
+kubectl delete pod registry-test \
+  --kubeconfig=/var/lib/kubesolo/pki/admin/admin.kubeconfig
+```

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -52,7 +52,6 @@ func (s *service) generateContainerdConfig() map[string]any {
 		"disabled_plugins": []string{},
 		"required_plugins": []string{},
 		"oom_score":        0,
-		"imports":          []string{types.DefaultContainerdConfigDir + "/*.toml"},
 		"grpc": map[string]any{
 			"address": s.containerdSocketFile,
 			"uid":     0,
@@ -72,7 +71,7 @@ func (s *service) generateContainerdConfig() map[string]any {
 					"sandbox": types.DefaultSandboxImage,
 				},
 				"registry": map[string]any{
-					"config_path": "",
+					"config_path": s.containerdRegistryConfigDir,
 				},
 				"image_decryption": map[string]any{
 					"key_model": "node",

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -52,6 +52,7 @@ func (s *service) generateContainerdConfig() map[string]any {
 		"disabled_plugins": []string{},
 		"required_plugins": []string{},
 		"oom_score":        0,
+		"imports":          []string{types.DefaultContainerdConfigDir + "/*.toml"},
 		"grpc": map[string]any{
 			"address": s.containerdSocketFile,
 			"uid":     0,

--- a/pkg/runtime/containerd/service.go
+++ b/pkg/runtime/containerd/service.go
@@ -20,6 +20,7 @@ type service struct {
 	containerdStateDir            string
 	containerdSocketFile          string
 	containerdCNIPluginsDir       string
+	containerdRegistryConfigDir   string
 	runcBinaryFile                string
 	containerdShimBinaryFile      string
 	portainerAgentImageFile       string
@@ -42,6 +43,7 @@ func NewService(ctx context.Context, cancel context.CancelFunc, containerdReady 
 		containerdStateDir:            embedded.ContainerdStateDir,
 		containerdSocketFile:          embedded.ContainerdSocketFile,
 		containerdCNIPluginsDir:       embedded.ContainerdCNIPluginsDir,
+		containerdRegistryConfigDir:   embedded.ContainerdRegistryConfigDir,
 		runcBinaryFile:                embedded.RuncBinaryFile,
 		containerdShimBinaryFile:      embedded.ContainerdShimBinaryFile,
 		portainerAgentImageFile:       embedded.PortainerAgentImageFile,

--- a/types/const.go
+++ b/types/const.go
@@ -13,6 +13,7 @@ const (
 	DefaultContainerdSocket          = "containerd.sock"
 	DefaultSystemContainerdSock      = "/run/containerd/containerd.sock"
 	DefaultStandardCNIConfDir        = "/etc/cni/net.d"
+	DefaultContainerdConfigDir       = "/etc/containerd/config.d"
 	DefaultContainerdRegistryDir     = "registry"
 	DefaultCNIConfigName             = "10-bridge.conflist"
 	DefaultK8sNamespace              = "k8s.io"

--- a/types/const.go
+++ b/types/const.go
@@ -14,7 +14,6 @@ const (
 	DefaultSystemContainerdSock      = "/run/containerd/containerd.sock"
 	DefaultStandardCNIConfDir        = "/etc/cni/net.d"
 	DefaultContainerdConfigDir       = "/etc/containerd/config.d"
-	DefaultContainerdRegistryDir     = "registry"
 	DefaultCNIConfigName             = "10-bridge.conflist"
 	DefaultK8sNamespace              = "k8s.io"
 	DefaultKubeletDir                = "kubelet"

--- a/types/const.go
+++ b/types/const.go
@@ -13,7 +13,7 @@ const (
 	DefaultContainerdSocket          = "containerd.sock"
 	DefaultSystemContainerdSock      = "/run/containerd/containerd.sock"
 	DefaultStandardCNIConfDir        = "/etc/cni/net.d"
-	DefaultContainerdConfigDir       = "/etc/containerd/config.d"
+	DefaultContainerdRegistryDir     = "registry"
 	DefaultCNIConfigName             = "10-bridge.conflist"
 	DefaultK8sNamespace              = "k8s.io"
 	DefaultKubeletDir                = "kubelet"

--- a/types/types.go
+++ b/types/types.go
@@ -73,14 +73,15 @@ type Embedded struct {
 	RequestHeaderCerts     RequestHeaderCertificatePaths
 
 	// Containerd directories and files
-	ContainerdDir            string
-	ContainerdSocketFile     string
-	ContainerdBinaryFile     string
-	ContainerdImagesDir      string
-	ContainerdConfigFile     string
-	ContainerdShimBinaryFile string
-	ContainerdRootDir        string
-	ContainerdStateDir       string
+	ContainerdDir               string
+	ContainerdSocketFile        string
+	ContainerdBinaryFile        string
+	ContainerdImagesDir         string
+	ContainerdConfigFile        string
+	ContainerdShimBinaryFile    string
+	ContainerdRootDir           string
+	ContainerdStateDir          string
+	ContainerdRegistryConfigDir string
 
 	// Conitainerd CNI directories and files
 	ContainerdCNIDir        string


### PR DESCRIPTION
Ref: [KS-34](https://linear.app/portainer/issue/KS-34/enable-containerd-registry-configuration-via-hoststoml)