### PR TITLE
fix(networking): own pod egress masquerade to fix agent connectivity …

### DIFF
--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -131,11 +131,14 @@ func (s *kubesolo) run() {
 	}
 	log.Info().Str("component", "kubesolo").Msg("starting kubesolo services... this may take a few minutes...")
 
-	services := []struct {
+	type service struct {
 		name    string
 		start   func()
 		readyCh chan struct{}
-	}{
+	}
+
+	// infraServices must be fully ready before pod masquerade is set up.
+	infraServices := []service{
 		{
 			name: "containerd",
 			start: func() {
@@ -176,6 +179,10 @@ func (s *kubesolo) run() {
 			},
 			readyCh: controllerReadyCh,
 		},
+	}
+
+	// nodeServices start after masquerade is guaranteed to be in place.
+	nodeServices := []service{
 		{
 			name: "kubelet",
 			start: func() {
@@ -198,7 +205,23 @@ func (s *kubesolo) run() {
 		},
 	}
 
-	for _, svc := range services {
+	for _, svc := range infraServices {
+		log.Info().Str("component", "kubesolo").Msgf("starting %s...", svc.name)
+		svc.start()
+		if !waitForService(ctx, svc.name, svc.readyCh) {
+			return
+		}
+	}
+
+	// Ensure pod→external masquerade (SNAT) is in place before kubelet starts.
+	// kine persists cluster state across reboots, so kubelet will immediately
+	// reconcile existing pods — they must not start into a network with no SNAT.
+	log.Info().Str("component", "kubesolo").Msg("setting up pod masquerade rules...")
+	if err := network.EnsurePodMasquerade(types.DefaultPodCIDR); err != nil {
+		log.Fatal().Err(err).Msg("failed to set up pod masquerade")
+	}
+
+	for _, svc := range nodeServices {
 		log.Info().Str("component", "kubesolo").Msgf("starting %s...", svc.name)
 		svc.start()
 		if !waitForService(ctx, svc.name, svc.readyCh) {

--- a/internal/core/embedded/config.go
+++ b/internal/core/embedded/config.go
@@ -12,7 +12,7 @@ func generateCNIConfigFile() map[string]any {
 				"type":        "bridge",
 				"bridge":      "cni0",
 				"isGateway":   true,
-				"ipMasq":      true,
+				"ipMasq":      false,
 				"hairpinMode": true,
 				"capabilities": map[string]any{
 					"portMappings": true,

--- a/internal/runtime/network/masquerade.go
+++ b/internal/runtime/network/masquerade.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/portainer/kubesolo/types"
+	"github.com/rs/zerolog/log"
+)
+
+const masqueradeComment = "kubesolo: pod masquerade"
+
+// EnsurePodMasquerade programs a SNAT/masquerade rule for pod egress traffic so
+// pods can reach external IPs. It is idempotent and mode-aware: iptables on
+// systems that have the ip_tables kernel module, nftables otherwise.
+//
+// This must be called before kubelet starts (so no pod ever starts without SNAT
+// in place) and after flushNftablesNat (to restore the rule after the nat table
+// is flushed for kube-proxy compatibility).
+func EnsurePodMasquerade(podCIDR string) error {
+	if _, err := os.Stat("/proc/net/ip_tables_names"); err == nil {
+		return ensureIPTablesMasquerade(podCIDR)
+	}
+	return ensureNftablesMasquerade(podCIDR)
+}
+
+func ensureIPTablesMasquerade(podCIDR string) error {
+	args := []string{
+		"-t", "nat", "-C", "POSTROUTING",
+		"-s", podCIDR, "!", "-d", podCIDR,
+		"-m", "comment", "--comment", masqueradeComment,
+		"-j", "MASQUERADE",
+	}
+
+	if err := exec.Command("iptables", args...).Run(); err == nil {
+		log.Debug().Str("component", "network").Msg("pod masquerade rule already present (iptables)")
+		return nil
+	}
+
+	args[2] = "-A"
+	if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("iptables: failed to add pod masquerade rule: %v (output: %s)", err, out)
+	}
+
+	log.Info().Str("component", "network").
+		Str("cidr", podCIDR).
+		Msg("added pod masquerade rule (iptables)")
+	return nil
+}
+
+func ensureNftablesMasquerade(podCIDR string) error {
+	out, _ := exec.Command("nft", "list", "table", "ip", types.DefaultNftMasqTable).CombinedOutput()
+	if strings.Contains(string(out), masqueradeComment) {
+		log.Debug().Str("component", "network").Msg("pod masquerade rule already present (nftables)")
+		return nil
+	}
+
+	cmds := [][]string{
+		{"nft", "add", "table", "ip", types.DefaultNftMasqTable},
+		{"nft", "add", "chain", "ip", types.DefaultNftMasqTable, "postrouting",
+			"{ type nat hook postrouting priority srcnat; policy accept; }"},
+		{"nft", "add", "rule", "ip", types.DefaultNftMasqTable, "postrouting",
+			"ip", "saddr", podCIDR, "ip", "daddr", "!=", podCIDR,
+			"masquerade", "comment", `"` + masqueradeComment + `"`},
+	}
+
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			return fmt.Errorf("nft %s: %v (output: %s)", strings.Join(args[1:], " "), err, out)
+		}
+	}
+
+	log.Info().Str("component", "network").
+		Str("cidr", podCIDR).
+		Str("table", types.DefaultNftMasqTable).
+		Msg("added pod masquerade rule (nftables)")
+	return nil
+}

--- a/internal/runtime/network/masquerade.go
+++ b/internal/runtime/network/masquerade.go
@@ -43,7 +43,7 @@ func ensureIPTablesMasquerade(podCIDR string) error {
 		return nil
 	}
 
-	args[3] = "-A"
+	args[4] = "-A"
 	if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("iptables: failed to add pod masquerade rule: %v (output: %s)", err, out)
 	}

--- a/internal/runtime/network/masquerade.go
+++ b/internal/runtime/network/masquerade.go
@@ -51,25 +51,36 @@ func ensureIPTablesMasquerade(podCIDR string) error {
 }
 
 func ensureNftablesMasquerade(podCIDR string) error {
-	out, _ := exec.Command("nft", "list", "table", "ip", types.DefaultNftMasqTable).CombinedOutput()
-	if strings.Contains(string(out), masqueradeComment) {
+	present, err := nftRulePresent(types.DefaultNftMasqTable, masqueradeComment)
+	if err != nil {
+		return err
+	}
+	if present {
 		log.Debug().Str("component", "network").Msg("pod masquerade rule already present (nftables)")
 		return nil
 	}
 
-	cmds := [][]string{
-		{"nft", "add", "table", "ip", types.DefaultNftMasqTable},
-		{"nft", "add", "chain", "ip", types.DefaultNftMasqTable, "postrouting",
-			"{ type nat hook postrouting priority srcnat; policy accept; }"},
-		{"nft", "add", "rule", "ip", types.DefaultNftMasqTable, "postrouting",
-			"ip", "saddr", podCIDR, "ip", "daddr", "!=", podCIDR,
-			"masquerade", "comment", `"` + masqueradeComment + `"`},
+	// Create table — idempotent: nft add table succeeds even if it already exists.
+	if out, err := exec.Command("nft", "add", "table", "ip", types.DefaultNftMasqTable).CombinedOutput(); err != nil {
+		return fmt.Errorf("nft add table %s: %v (output: %s)", types.DefaultNftMasqTable, err, out)
 	}
 
-	for _, args := range cmds {
-		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
-			return fmt.Errorf("nft %s: %v (output: %s)", strings.Join(args[1:], " "), err, out)
-		}
+	// Create base chain — tolerate "already exists" because the chain may be
+	// present from a previous partial run while the masquerade rule is missing.
+	chainOut, chainErr := exec.Command("nft", "add", "chain", "ip", types.DefaultNftMasqTable, "postrouting",
+		"{ type nat hook postrouting priority srcnat; policy accept; }").CombinedOutput()
+	if chainErr != nil && !strings.Contains(strings.ToLower(string(chainOut)), "already exists") {
+		return fmt.Errorf("nft add chain postrouting: %v (output: %s)", chainErr, chainOut)
+	}
+
+	// Add masquerade rule.
+	ruleArgs := []string{
+		"add", "rule", "ip", types.DefaultNftMasqTable, "postrouting",
+		"ip", "saddr", podCIDR, "ip", "daddr", "!=", podCIDR,
+		"masquerade", "comment", `"` + masqueradeComment + `"`,
+	}
+	if out, err := exec.Command("nft", ruleArgs...).CombinedOutput(); err != nil {
+		return fmt.Errorf("nft add rule masquerade: %v (output: %s)", err, out)
 	}
 
 	log.Info().Str("component", "network").
@@ -77,4 +88,21 @@ func ensureNftablesMasquerade(podCIDR string) error {
 		Str("table", types.DefaultNftMasqTable).
 		Msg("added pod masquerade rule (nftables)")
 	return nil
+}
+
+// nftRulePresent reports whether the named table contains a rule matching
+// comment. It returns an error only for unexpected failures — a missing table
+// is not an error, it simply means the rule is absent.
+func nftRulePresent(table, comment string) (bool, error) {
+	out, err := exec.Command("nft", "list", "table", "ip", table).CombinedOutput()
+	if err != nil {
+		outLower := strings.ToLower(string(out))
+		if strings.Contains(outLower, "no such file") ||
+			strings.Contains(outLower, "table not found") ||
+			strings.Contains(outLower, "no such table") {
+			return false, nil
+		}
+		return false, fmt.Errorf("nft list table %s: %v (output: %s)", table, err, out)
+	}
+	return strings.Contains(string(out), comment), nil
 }

--- a/internal/runtime/network/masquerade.go
+++ b/internal/runtime/network/masquerade.go
@@ -27,7 +27,11 @@ func EnsurePodMasquerade(podCIDR string) error {
 }
 
 func ensureIPTablesMasquerade(podCIDR string) error {
+	// -w 5: wait up to 5 s for the xtables lock. This function is called during
+	// kube-proxy startup when other processes may also be modifying iptables;
+	// without -w, concurrent access causes "Resource temporarily unavailable".
 	args := []string{
+		"-w", "5",
 		"-t", "nat", "-C", "POSTROUTING",
 		"-s", podCIDR, "!", "-d", podCIDR,
 		"-m", "comment", "--comment", masqueradeComment,
@@ -39,7 +43,7 @@ func ensureIPTablesMasquerade(podCIDR string) error {
 		return nil
 	}
 
-	args[2] = "-A"
+	args[3] = "-A"
 	if out, err := exec.Command("iptables", args...).CombinedOutput(); err != nil {
 		return fmt.Errorf("iptables: failed to add pod masquerade rule: %v (output: %s)", err, out)
 	}
@@ -50,37 +54,60 @@ func ensureIPTablesMasquerade(podCIDR string) error {
 	return nil
 }
 
+func nftCombinedOutput(args ...string) ([]byte, error) {
+	return exec.Command("nft", args...).CombinedOutput()
+}
+
+func nftAlreadyExists(out []byte) bool {
+	msg := strings.ToLower(string(out))
+	return strings.Contains(msg, "file exists") || strings.Contains(msg, "already exists")
+}
+
+// ensureNftObject ensures an nftables object (table or chain) exists. It tries
+// listArgs first; if the object is absent it runs addArgs, tolerating a
+// concurrent creation racing us to it.
+func ensureNftObject(listArgs, addArgs []string) error {
+	if _, err := nftCombinedOutput(listArgs...); err == nil {
+		return nil
+	}
+	if out, err := nftCombinedOutput(addArgs...); err != nil && !nftAlreadyExists(out) {
+		return fmt.Errorf("nft %s: %v (output: %s)", strings.Join(addArgs, " "), err, out)
+	}
+	return nil
+}
+
 func ensureNftablesMasquerade(podCIDR string) error {
-	present, err := nftRulePresent(types.DefaultNftMasqTable, masqueradeComment)
-	if err != nil {
+	if err := ensureNftObject(
+		[]string{"list", "table", "ip", types.DefaultNftMasqTable},
+		[]string{"add", "table", "ip", types.DefaultNftMasqTable},
+	); err != nil {
 		return err
 	}
-	if present {
+
+	if err := ensureNftObject(
+		[]string{"list", "chain", "ip", types.DefaultNftMasqTable, "postrouting"},
+		[]string{"add", "chain", "ip", types.DefaultNftMasqTable, "postrouting",
+			"{ type nat hook postrouting priority srcnat; policy accept; }"},
+	); err != nil {
+		return err
+	}
+
+	out, err := nftCombinedOutput("list", "chain", "ip", types.DefaultNftMasqTable, "postrouting")
+	if err != nil {
+		return fmt.Errorf("nft list chain ip %s postrouting: %v (output: %s)", types.DefaultNftMasqTable, err, out)
+	}
+	if strings.Contains(string(out), masqueradeComment) {
 		log.Debug().Str("component", "network").Msg("pod masquerade rule already present (nftables)")
 		return nil
 	}
 
-	// Create table — idempotent: nft add table succeeds even if it already exists.
-	if out, err := exec.Command("nft", "add", "table", "ip", types.DefaultNftMasqTable).CombinedOutput(); err != nil {
-		return fmt.Errorf("nft add table %s: %v (output: %s)", types.DefaultNftMasqTable, err, out)
-	}
-
-	// Create base chain — tolerate "already exists" because the chain may be
-	// present from a previous partial run while the masquerade rule is missing.
-	chainOut, chainErr := exec.Command("nft", "add", "chain", "ip", types.DefaultNftMasqTable, "postrouting",
-		"{ type nat hook postrouting priority srcnat; policy accept; }").CombinedOutput()
-	if chainErr != nil && !strings.Contains(strings.ToLower(string(chainOut)), "already exists") {
-		return fmt.Errorf("nft add chain postrouting: %v (output: %s)", chainErr, chainOut)
-	}
-
-	// Add masquerade rule.
-	ruleArgs := []string{
+	args := []string{
 		"add", "rule", "ip", types.DefaultNftMasqTable, "postrouting",
 		"ip", "saddr", podCIDR, "ip", "daddr", "!=", podCIDR,
 		"masquerade", "comment", `"` + masqueradeComment + `"`,
 	}
-	if out, err := exec.Command("nft", ruleArgs...).CombinedOutput(); err != nil {
-		return fmt.Errorf("nft add rule masquerade: %v (output: %s)", err, out)
+	if out, err := nftCombinedOutput(args...); err != nil {
+		return fmt.Errorf("nft %s: %v (output: %s)", strings.Join(args, " "), err, out)
 	}
 
 	log.Info().Str("component", "network").
@@ -88,21 +115,4 @@ func ensureNftablesMasquerade(podCIDR string) error {
 		Str("table", types.DefaultNftMasqTable).
 		Msg("added pod masquerade rule (nftables)")
 	return nil
-}
-
-// nftRulePresent reports whether the named table contains a rule matching
-// comment. It returns an error only for unexpected failures — a missing table
-// is not an error, it simply means the rule is absent.
-func nftRulePresent(table, comment string) (bool, error) {
-	out, err := exec.Command("nft", "list", "table", "ip", table).CombinedOutput()
-	if err != nil {
-		outLower := strings.ToLower(string(out))
-		if strings.Contains(outLower, "no such file") ||
-			strings.Contains(outLower, "table not found") ||
-			strings.Contains(outLower, "no such table") {
-			return false, nil
-		}
-		return false, fmt.Errorf("nft list table %s: %v (output: %s)", table, err, out)
-	}
-	return strings.Contains(string(out), comment), nil
 }

--- a/pkg/kubernetes/kubeproxy/executor.go
+++ b/pkg/kubernetes/kubeproxy/executor.go
@@ -94,7 +94,7 @@ func (s *service) postSetup() error {
 	// kube-proxy's own chains were programmed; this ensures kubeproxyReady only
 	// fires once SNAT for pod egress is confirmed.
 	if err := network.EnsurePodMasquerade(types.DefaultPodCIDR); err != nil {
-		log.Warn().Str("component", "kubeproxy").Msgf("failed to ensure pod masquerade: %v", err)
+		log.Error().Str("component", "kubeproxy").Msgf("failed to ensure pod masquerade: %v", err)
 	}
 	return nil
 }

--- a/pkg/kubernetes/kubeproxy/executor.go
+++ b/pkg/kubernetes/kubeproxy/executor.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/portainer/kubesolo/internal/runtime/network"
 	kubesoloservice "github.com/portainer/kubesolo/internal/runtime/service"
 	"github.com/portainer/kubesolo/types"
 	"github.com/rs/zerolog/log"
@@ -25,6 +26,12 @@ func flushNftablesNat() {
 		return
 	}
 	log.Info().Str("component", "kubeproxy").Msg("flushed nftables ip nat table to avoid iptables-nft conflicts")
+
+	// The flush above wipes CNI masquerade rules for already-running pods.
+	// Re-add immediately so the gap where pods have no SNAT is negligible.
+	if err := network.EnsurePodMasquerade(types.DefaultPodCIDR); err != nil {
+		log.Warn().Str("component", "kubeproxy").Msgf("failed to restore pod masquerade after nat flush: %v", err)
+	}
 }
 
 // Run starts the kube proxy in the following order:
@@ -82,6 +89,12 @@ func (s *service) postSetup() error {
 		log.Error().Str("component", "kubeproxy").Msgf("kubeproxy health check failed: %v...", err)
 		s.cancelShutdown()
 		return err
+	}
+	// Re-verify masquerade is in place. flushNftablesNat may have run before
+	// kube-proxy's own chains were programmed; this ensures kubeproxyReady only
+	// fires once SNAT for pod egress is confirmed.
+	if err := network.EnsurePodMasquerade(types.DefaultPodCIDR); err != nil {
+		log.Warn().Str("component", "kubeproxy").Msgf("failed to ensure pod masquerade: %v", err)
 	}
 	return nil
 }

--- a/types/const.go
+++ b/types/const.go
@@ -36,4 +36,5 @@ const (
 	DefaultContextTimeout            = 15 * time.Second
 	DefaultComponentSleep            = 5 * time.Second
 	DefaultRetryCount                = 5
+	DefaultNftMasqTable              = "kubesolo-masq"
 )


### PR DESCRIPTION
…after reboot

After a reboot, kine persists cluster state so kubelet immediately reconciles existing pods before kube-proxy has started. On nftables-only devices, kube-proxy never sets --masquerade-all and the bridge CNI's ipMasq silently fails (iptables commands with no kernel module). On iptables devices, flushNftablesNat() wipes CNI masquerade rules for already-running pods when kube-proxy starts. Both paths leave pods with no SNAT for pod->external traffic until the pod is manually deleted.

Decouple masquerade ownership from kube-proxy and CNI by introducing EnsurePodMasquerade() in internal/runtime/network — idempotent and mode-aware (iptables or nftables).

- Call EnsurePodMasquerade before kubelet starts in main.go so no pod ever starts without SNAT, even with kine-persisted state on reboot
- Re-apply immediately after flushNftablesNat() to close the gap for already-running pods; use an isolated kubesolo-masq nftables table that kube-proxy's nat flush never touches
- Call again in kube-proxy postSetup() so kubeproxyReady only fires once masquerade is confirmed programmed
- Set ipMasq: false in CNI bridge config — bridge plugin's iptables masquerade is now redundant and broken on nftables-only systems