### PR TITLE
feat(config): add --full flag and strip redundant upstream defaults (…

### DIFF
--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -48,6 +48,7 @@ type kubesolo struct {
 	loadBalancer           bool
 	localStorage           bool
 	localStorageSharedPath string
+	fullMode               bool
 	embedded               types.Embedded
 }
 
@@ -74,6 +75,7 @@ func service() (*kubesolo, error) {
 		loadBalancer:           *flags.LoadBalancer,
 		localStorage:           *flags.LocalStorage,
 		localStorageSharedPath: *flags.LocalStorageSharedPath,
+		fullMode:               *flags.Full,
 	}, nil
 }
 
@@ -114,10 +116,16 @@ func (s *kubesolo) run() {
 		cancel()
 	}()
 
+	profile := "edge"
+	if s.fullMode {
+		profile = "full"
+	}
+
 	log.Info().
 		Str("version", Version).
 		Str("build-date", BuildDate).
 		Str("commit", Commit).
+		Str("profile", profile).
 		Msg("starting kubesolo...")
 
 	log.Info().Str("component", "kubesolo").Msg("ensuring all embedded dependencies are available...")
@@ -196,7 +204,7 @@ func (s *kubesolo) run() {
 		{
 			name: "kubeproxy",
 			start: func() {
-				kubeproxyService := kubeproxy.NewService(ctx, cancel, kubeproxyReadyCh, s.embedded.AdminKubeconfigFile)
+				kubeproxyService := kubeproxy.NewService(ctx, cancel, kubeproxyReadyCh, s.embedded.AdminKubeconfigFile, s.embedded.FullMode)
 				s.wg.Go(func() {
 					kubeproxyService.Run(kubeletReadyCh)
 				})
@@ -420,12 +428,12 @@ func (s *kubesolo) bootstrap() {
 		},
 
 		// Containerd paths
-		ContainerdDir:            filepath.Join(basePath, types.DefaultContainerdDir),
-		ContainerdSocketFile:     filepath.Join(basePath, types.DefaultContainerdDir, types.DefaultContainerdSocket),
-		ContainerdBinaryFile:     filepath.Join(basePath, types.DefaultContainerdDir, "containerd"),
-		ContainerdImagesDir:      filepath.Join(basePath, types.DefaultContainerdDir, "images"),
-		ContainerdShimBinaryFile: filepath.Join(basePath, types.DefaultContainerdDir, "containerd-shim-runc-v2"),
-		ContainerdConfigFile:     filepath.Join(basePath, types.DefaultContainerdDir, "config.toml"),
+		ContainerdDir:               filepath.Join(basePath, types.DefaultContainerdDir),
+		ContainerdSocketFile:        filepath.Join(basePath, types.DefaultContainerdDir, types.DefaultContainerdSocket),
+		ContainerdBinaryFile:        filepath.Join(basePath, types.DefaultContainerdDir, "containerd"),
+		ContainerdImagesDir:         filepath.Join(basePath, types.DefaultContainerdDir, "images"),
+		ContainerdShimBinaryFile:    filepath.Join(basePath, types.DefaultContainerdDir, "containerd-shim-runc-v2"),
+		ContainerdConfigFile:        filepath.Join(basePath, types.DefaultContainerdDir, "config.toml"),
 		ContainerdRootDir:           filepath.Join(basePath, types.DefaultContainerdDir, "root"),
 		ContainerdStateDir:          filepath.Join(basePath, types.DefaultContainerdDir, "state"),
 		ContainerdRegistryConfigDir: filepath.Join(basePath, types.DefaultContainerdDir, "registry"),
@@ -476,5 +484,8 @@ func (s *kubesolo) bootstrap() {
 
 		// Portainer Edge
 		IsPortainerEdge: s.portainerEdgeID != "" && s.portainerEdgeKey != "",
+
+		// Full mode
+		FullMode: s.fullMode,
 	}
 }

--- a/internal/config/flags/flags.go
+++ b/internal/config/flags/flags.go
@@ -25,4 +25,5 @@ var (
 	LocalStorageSharedPath = Application.Flag("local-storage-shared-path", "Path to the shared file system for the local storage. Defaults to empty string.").Envar("KUBESOLO_LOCAL_STORAGE_SHARED_PATH").Default("").String()
 	Debug                  = Application.Flag("debug", "Enable debug logging. Defaults to false.").Envar("KUBESOLO_DEBUG").Default("false").Bool()
 	PprofServer            = Application.Flag("pprof-server", "Enable pprof server. Defaults to false.").Envar("KUBESOLO_PPROF_SERVER").Default("false").Bool()
+	Full                   = Application.Flag("full", "Disable memory-saving overrides and use upstream Kubernetes defaults. Kubesolo still uses NodeSetter in favour of the scheduler. Recommended for CI and developer environments where memory is not constrained. Leave unset for edge deployments.").Envar("KUBESOLO_FULL").Default("false").Bool()
 )

--- a/pkg/kubernetes/apiserver/flags.go
+++ b/pkg/kubernetes/apiserver/flags.go
@@ -10,16 +10,11 @@ func (s *service) configureAPIServerFlags(command *cobra.Command) error {
 
 	// networking settings
 	_ = flags.Set("insecure-port", "0")
-	_ = flags.Set("secure-port", "6443")
-	_ = flags.Set("bind-address", "0.0.0.0")
 	_ = flags.Set("advertise-address", s.nodeIP)
 	_ = flags.Set("service-cluster-ip-range", types.DefaultServiceClusterIPRange)
 
 	// etcd configuration
 	_ = flags.Set("etcd-servers", types.DefaultKineEndpoint)
-	_ = flags.Set("etcd-compaction-interval", "5m")
-	_ = flags.Set("etcd-count-metric-poll-period", "0")
-	_ = flags.Set("etcd-db-metric-poll-interval", "0")
 
 	// security and certificates
 	_ = flags.Set("cert-dir", s.pkiAPIServerDir)
@@ -40,33 +35,40 @@ func (s *service) configureAPIServerFlags(command *cobra.Command) error {
 	_ = flags.Set("proxy-client-cert-file", s.requestHeaderClientCert)
 	_ = flags.Set("proxy-client-key-file", s.requestHeaderClientKey)
 
-	// authorization and admission
+	// authorization
 	_ = flags.Set("allow-privileged", "true")
 	_ = flags.Set("authorization-mode", "Node,RBAC")
-	_ = flags.Set("enable-admission-plugins", "NodeRestriction,ServiceAccount,ValidatingAdmissionWebhook,MutatingAdmissionWebhook,DefaultStorageClass,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,ValidatingAdmissionPolicy,MutatingAdmissionPolicy")
-	_ = flags.Set("disable-admission-plugins", "RuntimeClass,PodSecurity,ClusterTrustBundleAttest,DefaultIngressClass,TaintNodesByCondition,DefaultTolerationSeconds,StorageObjectInUseProtection,PersistentVolumeClaimResize,ResourceQuota,LimitRanger,Priority")
-	_ = flags.Set("enable-bootstrap-token-auth", "false")
-
-	// performance and resource limits
-	_ = flags.Set("max-requests-inflight", "2000")
-	_ = flags.Set("max-mutating-requests-inflight", "1000")
-	_ = flags.Set("min-request-timeout", "180")
-	_ = flags.Set("request-timeout", "900s")
-	_ = flags.Set("kubelet-timeout", "30s")
-	_ = flags.Set("watch-cache", "true")
-	_ = flags.Set("event-ttl", "1h")
-
-	// features and garbage collection
-	_ = flags.Set("enable-garbage-collector", "true")
-	_ = flags.Set("profiling", "false")
 
 	// feature gates - disable SizeBasedListCostEstimate to suppress "Error getting keys" messages
 	_ = flags.Set("feature-gates", "SizeBasedListCostEstimate=false")
 
-	// audit logging
-	_ = flags.Set("audit-log-path", "-")
-	_ = flags.Set("audit-log-maxage", "0")
-	_ = flags.Set("audit-log-maxbackup", "0")
-	_ = flags.Set("audit-log-maxsize", "0")
+	// Edge-optimised overrides — only applied when not in full mode.
+	// When full mode is enabled, upstream Kubernetes defaults are used instead.
+	if !s.fullMode {
+		// etcd metric collection
+		_ = flags.Set("etcd-count-metric-poll-period", "0")
+		_ = flags.Set("etcd-db-metric-poll-interval", "0")
+
+		// request throttling and timeouts
+		_ = flags.Set("max-requests-inflight", "2000")
+		_ = flags.Set("max-mutating-requests-inflight", "1000")
+		_ = flags.Set("min-request-timeout", "180")
+		_ = flags.Set("request-timeout", "900s")
+		_ = flags.Set("kubelet-timeout", "30s")
+
+		// diagnostics
+		_ = flags.Set("profiling", "false")
+
+		// admission control
+		_ = flags.Set("enable-admission-plugins", "NodeRestriction,ServiceAccount,ValidatingAdmissionWebhook,MutatingAdmissionWebhook,DefaultStorageClass,CertificateApproval,CertificateSigning,CertificateSubjectRestriction,ValidatingAdmissionPolicy,MutatingAdmissionPolicy")
+		_ = flags.Set("disable-admission-plugins", "RuntimeClass,PodSecurity,ClusterTrustBundleAttest,DefaultIngressClass,TaintNodesByCondition,DefaultTolerationSeconds,StorageObjectInUseProtection,PersistentVolumeClaimResize,ResourceQuota,LimitRanger,Priority")
+
+		// audit logging
+		_ = flags.Set("audit-log-path", "-")
+		_ = flags.Set("audit-log-maxage", "0")
+		_ = flags.Set("audit-log-maxbackup", "0")
+		_ = flags.Set("audit-log-maxsize", "0")
+	}
+
 	return nil
 }

--- a/pkg/kubernetes/apiserver/service.go
+++ b/pkg/kubernetes/apiserver/service.go
@@ -28,6 +28,7 @@ type service struct {
 	requestHeaderCAFile     string
 	requestHeaderClientCert string
 	requestHeaderClientKey  string
+	fullMode                bool
 	kubeSoloWebhook         *webhook.Service
 }
 
@@ -51,6 +52,7 @@ func NewService(ctx context.Context, cancel context.CancelFunc, apiServerReady c
 		requestHeaderCAFile:     embedded.RequestHeaderCerts.CACert,
 		requestHeaderClientCert: embedded.RequestHeaderCerts.ClientCert,
 		requestHeaderClientKey:  embedded.RequestHeaderCerts.ClientKey,
+		fullMode:                embedded.FullMode,
 		kubeSoloWebhook:         webhook.NewService(nodeName, embedded.NodeIP, embedded.PKIDir, embedded.AdminKubeconfigFile, embedded.LoadBalancer),
 	}
 }

--- a/pkg/kubernetes/controller/flags.go
+++ b/pkg/kubernetes/controller/flags.go
@@ -9,11 +9,8 @@ func (s *service) configureControllerManagerFlags(command *cobra.Command) {
 	flags := command.Flags()
 
 	// controller manager settings
-	_ = flags.Set("bind-address", "0.0.0.0")
-	_ = flags.Set("secure-port", "10257")
 	_ = flags.Set("allocate-node-cidrs", "true")
 	_ = flags.Set("cluster-cidr", types.DefaultPodCIDR)
-	_ = flags.Set("v", "0")
 	_ = flags.Set("service-account-private-key-file", s.serviceAccountKeyFile)
 	_ = flags.Set("kubeconfig", s.adminKubeconfigFile)
 	_ = flags.Set("authentication-kubeconfig", s.adminKubeconfigFile)
@@ -23,50 +20,51 @@ func (s *service) configureControllerManagerFlags(command *cobra.Command) {
 	_ = flags.Set("tls-cert-file", s.controllerManagerCertFile)
 	_ = flags.Set("tls-private-key-file", s.controllerManagerKeyFile)
 	_ = flags.Set("leader-elect", "false")
-	_ = flags.Set("profiling", "false")
 	_ = flags.Set("use-service-account-credentials", "true")
 
-	// controllers
-	_ = flags.Set("controllers", "deployment,replicaset,service,serviceaccount,namespace,attachdetach,endpoint,daemonset,statefulset,root-ca-certificate-publisher-controller,serviceaccount-token-controller,node-ipam-controller,endpointslice-controller,persistentvolume-binder-controller,job-controller,cronjob-controller,garbage-collector-controller,disruption,csrsigning,clusterrole-aggregation")
+	// Edge-optimised overrides — only applied when not in full mode.
+	// When full mode is enabled, upstream Kubernetes defaults are used instead.
+	if !s.fullMode {
+		// controllers
+		_ = flags.Set("controllers", "deployment,replicaset,service,serviceaccount,namespace,attachdetach,endpoint,daemonset,statefulset,root-ca-certificate-publisher-controller,serviceaccount-token-controller,node-ipam-controller,endpointslice-controller,persistentvolume-binder-controller,job-controller,cronjob-controller,garbage-collector-controller,disruption,csrsigning,clusterrole-aggregation")
 
-	// thresholds
-	_ = flags.Set("terminated-pod-gc-threshold", "20")
-	_ = flags.Set("large-cluster-size-threshold", "10")
-	_ = flags.Set("unhealthy-zone-threshold", "0.7")
+		_ = flags.Set("profiling", "false")
+		_ = flags.Set("terminated-pod-gc-threshold", "20")
+		_ = flags.Set("large-cluster-size-threshold", "10")
+		_ = flags.Set("unhealthy-zone-threshold", "0.7")
 
-	// sync settings
-	_ = flags.Set("concurrent-deployment-syncs", "2")
-	_ = flags.Set("concurrent-replicaset-syncs", "2")
-	_ = flags.Set("concurrent-daemonset-syncs", "2")
-	_ = flags.Set("concurrent-job-syncs", "2")
-	_ = flags.Set("concurrent-endpoint-syncs", "2")
-	_ = flags.Set("concurrent-service-endpoint-syncs", "2")
-	_ = flags.Set("concurrent-gc-syncs", "2")
-	_ = flags.Set("concurrent-namespace-syncs", "2")
-	_ = flags.Set("concurrent-cron-job-syncs", "2")
-	_ = flags.Set("concurrent-horizontal-pod-autoscaler-syncs", "2")
-	_ = flags.Set("concurrent-rc-syncs", "2")
-	_ = flags.Set("concurrent-resource-quota-syncs", "2")
-	_ = flags.Set("concurrent-service-syncs", "2")
-	_ = flags.Set("concurrent-serviceaccount-token-syncs", "2")
-	_ = flags.Set("concurrent-statefulset-syncs", "2")
-	_ = flags.Set("concurrent-ttl-after-finished-syncs", "2")
-	_ = flags.Set("concurrent-ephemeralvolume-syncs", "2")
-	_ = flags.Set("concurrent-validating-admission-policy-status-syncs", "2")
-	_ = flags.Set("mirroring-concurrent-service-endpoint-syncs", "2")
+		// sync settings
+		_ = flags.Set("concurrent-deployment-syncs", "2")
+		_ = flags.Set("concurrent-replicaset-syncs", "2")
+		_ = flags.Set("concurrent-job-syncs", "2")
+		_ = flags.Set("concurrent-endpoint-syncs", "2")
+		_ = flags.Set("concurrent-service-endpoint-syncs", "2")
+		_ = flags.Set("concurrent-gc-syncs", "2")
+		_ = flags.Set("concurrent-namespace-syncs", "2")
+		_ = flags.Set("concurrent-cron-job-syncs", "2")
+		_ = flags.Set("concurrent-horizontal-pod-autoscaler-syncs", "2")
+		_ = flags.Set("concurrent-rc-syncs", "2")
+		_ = flags.Set("concurrent-resource-quota-syncs", "2")
+		_ = flags.Set("concurrent-service-syncs", "2")
+		_ = flags.Set("concurrent-serviceaccount-token-syncs", "2")
+		_ = flags.Set("concurrent-statefulset-syncs", "2")
+		_ = flags.Set("concurrent-ttl-after-finished-syncs", "2")
+		_ = flags.Set("concurrent-ephemeralvolume-syncs", "2")
+		_ = flags.Set("concurrent-validating-admission-policy-status-syncs", "2")
+		_ = flags.Set("mirroring-concurrent-service-endpoint-syncs", "2")
 
-	// sync period
-	_ = flags.Set("horizontal-pod-autoscaler-sync-period", "60s")
-	_ = flags.Set("node-monitor-period", "60s")
-	_ = flags.Set("pvclaimbinder-sync-period", "120s")
-	_ = flags.Set("resource-quota-sync-period", "15m")
-	_ = flags.Set("namespace-sync-period", "15m")
-	_ = flags.Set("route-reconciliation-period", "60s")
-	_ = flags.Set("attach-detach-reconcile-sync-period", "10m")
-	_ = flags.Set("node-monitor-grace-period", "300s")
-	_ = flags.Set("min-resync-period", "12h")
+		// sync period
+		_ = flags.Set("horizontal-pod-autoscaler-sync-period", "60s")
+		_ = flags.Set("node-monitor-period", "60s")
+		_ = flags.Set("pvclaimbinder-sync-period", "120s")
+		_ = flags.Set("resource-quota-sync-period", "15m")
+		_ = flags.Set("namespace-sync-period", "15m")
+		_ = flags.Set("route-reconciliation-period", "60s")
+		_ = flags.Set("attach-detach-reconcile-sync-period", "10m")
+		_ = flags.Set("node-monitor-grace-period", "300s")
 
-	// api server interactions
-	_ = flags.Set("kube-api-qps", "50")
-	_ = flags.Set("kube-api-burst", "100")
+		// api server interactions
+		_ = flags.Set("kube-api-qps", "50")
+		_ = flags.Set("kube-api-burst", "100")
+	}
 }

--- a/pkg/kubernetes/controller/service.go
+++ b/pkg/kubernetes/controller/service.go
@@ -19,6 +19,7 @@ type service struct {
 	caFile                    string
 	adminKubeconfigFile       string
 	serviceAccountKeyFile     string
+	fullMode                  bool
 }
 
 // NewService creates a new controller service
@@ -33,5 +34,6 @@ func NewService(ctx context.Context, cancel context.CancelFunc, controllerReady 
 		caFile:                    embedded.CACerts.Cert,
 		adminKubeconfigFile:       embedded.AdminKubeconfigFile,
 		serviceAccountKeyFile:     embedded.ServiceAccountKeyFile,
+		fullMode:                  embedded.FullMode,
 	}
 }

--- a/pkg/kubernetes/kubelet/config.go
+++ b/pkg/kubernetes/kubelet/config.go
@@ -51,13 +51,11 @@ func (s *service) writeKubeletConfigFile() error {
 }
 
 func (s *service) generateKubeletConfig() map[string]any {
-	return map[string]any{
-		"kind":         "KubeletConfiguration",
-		"apiVersion":   "kubelet.config.k8s.io/v1beta1",
-		"enableServer": true,
+	config := map[string]any{
+		"kind":       "KubeletConfiguration",
+		"apiVersion": "kubelet.config.k8s.io/v1beta1",
 
 		"containerRuntimeEndpoint": "unix://" + s.containerdSockFile,
-		"imageServiceEndpoint":     "unix://" + s.containerdSockFile,
 
 		"authentication": map[string]any{
 			"anonymous": map[string]any{
@@ -88,52 +86,42 @@ func (s *service) generateKubeletConfig() map[string]any {
 
 		"cgroupDriver": cgroupDriver(),
 
-		"registerNode":                   true,
-		"readOnlyPort":                   0,
-		"port":                           10250,
-		"syncFrequency":                  "5m0s",
-		"fileCheckFrequency":             "2m0s",
-		"httpCheckFrequency":             "2m0s",
-		"nodeStatusUpdateFrequency":      "60s",
-		"nodeStatusReportFrequency":      "15m0s",
-		"volumeStatsAggPeriod":           "5m0s",
-		"imageMinimumGCAge":              "10m0s",
-		"imageMaximumGCAge":              "0s",
-		"imageGCHighThresholdPercent":    95,
-		"imageGCLowThresholdPercent":     80,
-		"runtimeRequestTimeout":          "60s",
-		"cpuManagerReconcilePeriod":      "60s",
-		"streamingConnectionIdleTimeout": "1h0m0s",
-		"rotateCertificates":             true,
+		"readOnlyPort":       0,
+		"rotateCertificates": true,
 
-		"registerWithTaints": []map[string]any{},
+		"failSwapOn": false,
+	}
 
-		"evictionHard": map[string]string{
+	// Edge-optimised overrides — only applied when not in full mode.
+	// When full mode is enabled, upstream Kubernetes defaults are used instead.
+	if !s.fullMode {
+		config["enableProfilingHandler"] = false
+		config["enableDebugFlagsHandler"] = false
+		config["streamingConnectionIdleTimeout"] = "1h0s"
+		config["syncFrequency"] = "5m0s"
+		config["fileCheckFrequency"] = "2m0s"
+		config["httpCheckFrequency"] = "2m0s"
+		config["nodeStatusUpdateFrequency"] = "60s"
+		config["nodeStatusReportFrequency"] = "15m0s"
+		config["volumeStatsAggPeriod"] = "5m0s"
+		config["imageMinimumGCAge"] = "10m0s"
+		config["imageMaximumGCAge"] = "0s"
+		config["imageGCHighThresholdPercent"] = 95
+		config["runtimeRequestTimeout"] = "60s"
+		config["cpuManagerReconcilePeriod"] = "60s"
+		config["kubeAPIQPS"] = 10
+		config["kubeAPIBurst"] = 20
+		config["eventRecordQPS"] = 5
+		config["eventBurst"] = 10
+		config["containerLogMaxSize"] = "512Ki"
+		config["maxPods"] = 20
+		config["evictionHard"] = map[string]string{
 			"memory.available": "75Mi",
 			"nodefs.available": "50Mi",
-		},
-		"systemReserved": map[string]string{"memory": "25Mi"},
-		"kubeReserved":   map[string]string{"memory": "25Mi"},
-		"failSwapOn":     false,
-
-		"kubeAPIQPS":                10,
-		"kubeAPIBurst":              20,
-		"serializeImagePulls":       true,
-		"imagePullProgressDeadline": "1m",
-
-		"registryPullQPS": 5,
-		"registryBurst":   10,
-
-		"eventRecordQPS": 5,
-		"eventBurst":     10,
-
-		"containerLogMaxSize":     "512Ki",
-		"enableProfilingHandler":  false,
-		"enableDebugFlagsHandler": false,
-		"maxPods":                 20,
-
-		"featureGates": map[string]bool{
-			"RotateKubeletServerCertificate": true,
-		},
+		}
+		config["systemReserved"] = map[string]string{"memory": "25Mi"}
+		config["kubeReserved"] = map[string]string{"memory": "25Mi"}
 	}
+
+	return config
 }

--- a/pkg/kubernetes/kubelet/service.go
+++ b/pkg/kubernetes/kubelet/service.go
@@ -28,6 +28,7 @@ type service struct {
 	nodeIP                string
 	kubeletCertPath       string
 	adminKubeconfig       string
+	fullMode              bool
 }
 
 // NewService creates a new kubelet service
@@ -49,5 +50,6 @@ func NewService(ctx context.Context, cancel context.CancelFunc, kubeletReady cha
 		keyFile:               embedded.KubeletCerts.Key,
 		nodeName:              system.GetHostname(),
 		adminKubeconfig:       embedded.AdminKubeconfigFile,
+		fullMode:              embedded.FullMode,
 	}
 }

--- a/pkg/kubernetes/kubeproxy/flags.go
+++ b/pkg/kubernetes/kubeproxy/flags.go
@@ -31,16 +31,17 @@ func (s *service) configureKubeProxyFlags(command *cobra.Command) {
 
 	// performance settings
 	_ = flags.Set("oom-score-adj", "-998")
-	_ = flags.Set("profiling", "false")
 
 	// proxy mode and conntrack settings
 	_ = flags.Set("proxy-mode", proxyMode)
-	_ = flags.Set("conntrack-max-per-core", "1024")
-	_ = flags.Set("conntrack-min", "1024")
-	_ = flags.Set("min-sync-period", "10s")
+	if !s.fullMode {
+		_ = flags.Set("profiling", "false")
+		_ = flags.Set("conntrack-max-per-core", "1024")
+		_ = flags.Set("conntrack-min", "1024")
+		_ = flags.Set("min-sync-period", "10s")
+	}
 
 	if proxyMode == "iptables" {
-		_ = flags.Set("iptables-masquerade-bit", "14")
 		_ = flags.Set("masquerade-all", "true")
 	}
 }

--- a/pkg/kubernetes/kubeproxy/service.go
+++ b/pkg/kubernetes/kubeproxy/service.go
@@ -12,14 +12,16 @@ type service struct {
 	cancel              context.CancelFunc
 	kubeproxyReady      chan<- struct{}
 	adminKubeconfigFile string
+	fullMode            bool
 }
 
 // NewService creates a new kube proxy service
-func NewService(ctx context.Context, cancel context.CancelFunc, kubeproxyReady chan<- struct{}, adminKubeconfigFile string) *service {
+func NewService(ctx context.Context, cancel context.CancelFunc, kubeproxyReady chan<- struct{}, adminKubeconfigFile string, fullMode bool) *service {
 	return &service{
 		ctx:                 ctx,
 		cancel:              cancel,
 		kubeproxyReady:      kubeproxyReady,
 		adminKubeconfigFile: adminKubeconfigFile,
+		fullMode:            fullMode,
 	}
 }

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -57,77 +57,24 @@ func (s *service) writeContainerdConfigFile() error {
 // generateConfig generates the containerd config
 func (s *service) generateContainerdConfig() map[string]any {
 	return map[string]any{
-		"version":          3,
-		"root":             s.containerdRootDir,
-		"state":            s.containerdStateDir,
-		"temp":             "",
-		"plugin_dir":       "",
-		"disabled_plugins": []string{},
-		"required_plugins": []string{},
-		"oom_score":        0,
-		"imports":          []string{types.DefaultContainerdConfigDir + "/*.toml"},
+		"version": 3,
+		"root":    s.containerdRootDir,
+		"state":   s.containerdStateDir,
+		"imports": []string{types.DefaultContainerdConfigDir + "/*.toml"},
 		"grpc": map[string]any{
 			"address": s.containerdSocketFile,
-			"uid":     0,
-			"gid":     0,
 		},
 
 		"plugins": map[string]any{
-			"io.containerd.cri.v1.images": map[string]any{
-				"snapshotter":                  "overlayfs",
-				"disable_snapshot_annotations": true,
-				"discard_unpacked_layers":      false,
-				"max_concurrent_downloads":     1,
-				"image_pull_progress_timeout":  "2m0s",
-				"image_pull_with_sync_fs":      false,
-				"stats_collect_period":         120,
-				"pinned_images": map[string]any{
-					"sandbox": types.DefaultSandboxImage,
-				},
-				"registry": map[string]any{
-					"config_path": s.containerdRegistryConfigDir,
-				},
-				"image_decryption": map[string]any{
-					"key_model": "node",
-				},
-			},
+			"io.containerd.cri.v1.images": s.generateCRIImagesConfig(),
 
 			"io.containerd.cri.v1.runtime": map[string]any{
-				"enable_selinux":                         false,
-				"selinux_category_range":                 1024,
-				"max_container_log_line_size":            16384,
-				"disable_apparmor":                       false,
-				"restrict_oom_score_adj":                 false,
-				"disable_proc_mount":                     false,
-				"unset_seccomp_profile":                  "",
-				"tolerate_missing_hugetlb_controller":    true,
-				"disable_hugetlb_controller":             true,
-				"device_ownership_from_security_context": false,
-				"ignore_image_defined_volumes":           false,
-				"netns_mounts_under_state_dir":           false,
-				"enable_unprivileged_ports":              true,
-				"enable_unprivileged_icmp":               true,
-				"enable_cdi":                             true,
-				"drain_exec_sync_io_timeout":             "0s",
-				"ignore_deprecation_warnings":            []string{},
 				"containerd": map[string]any{
-					"default_runtime_name":              "crun",
-					"ignore_blockio_not_enabled_errors": false,
-					"ignore_rdt_not_enabled_errors":     false,
+					"default_runtime_name": "crun",
 					"runtimes": map[string]any{
 						"crun": map[string]any{
-							"runtime_type":                    "io.containerd.runc.v2",
-							"runtime_path":                    s.containerdShimBinaryFile,
-							"pod_annotations":                 []string{},
-							"container_annotations":           []string{},
-							"privileged_without_host_devices": false,
-							"privileged_without_host_devices_all_devices_allowed": false,
-							"base_runtime_spec": "",
-							"cni_conf_dir":      "",
-							"cni_max_conf_num":  0,
-							"snapshotter":       "",
-							"sandboxer":         "podsandbox",
-							"io_type":           "",
+							"runtime_type": "io.containerd.runc.v2",
+							"runtime_path": s.containerdShimBinaryFile,
 							"options": map[string]any{
 								"BinaryName":    s.crunBinaryFile,
 								"SystemdCgroup": useSystemdCgroup(),
@@ -136,57 +83,55 @@ func (s *service) generateContainerdConfig() map[string]any {
 					},
 				},
 				"cni": map[string]any{
-					"bin_dir":               s.containerdCNIPluginsDir,
-					"conf_dir":              types.DefaultStandardCNIConfDir,
-					"max_conf_num":          1,
-					"setup_serially":        false,
-					"conf_template":         "",
-					"ip_pref":               "",
-					"use_internal_loopback": false,
+					"bin_dir":  s.containerdCNIPluginsDir,
+					"conf_dir": types.DefaultStandardCNIConfDir,
 				},
 			},
 
-			"io.containerd.gc.v1.scheduler": map[string]any{
-				"pause_threshold":    0.01,
-				"deletion_threshold": 0,
-				"mutation_threshold": 50,
-				"schedule_delay":     "5s",
-				"startup_delay":      "200ms",
-			},
-
-			"io.containerd.grpc.v1.cri": map[string]any{
-				"disable_tcp_service":   true,
-				"stream_server_address": "127.0.0.1",
-				"stream_server_port":    "0",
-				"stream_idle_timeout":   "4h0m0s",
-				"enable_tls_streaming":  false,
-			},
-
-			"io.containerd.snapshotter.v1.overlayfs": map[string]any{
-				"root_path":      "",
-				"upperdir_label": false,
-				"sync_remove":    false,
-				"slow_chown":     false,
-				"mount_options":  []string{},
-			},
+			"io.containerd.gc.v1.scheduler": s.generateGCSchedulerConfig(),
 
 			"io.containerd.runtime.v2.task": map[string]any{
 				"platforms": []string{"linux/amd64", "linux/arm64", "linux/arm"},
 			},
 		},
+	}
+}
 
-		"cgroup": map[string]any{
-			"path": "",
+// generateCRIImagesConfig returns the CRI images plugin configuration.
+// Edge-specific overrides (max_concurrent_downloads, stats_collect_period) are
+// only applied when not in full mode.
+func (s *service) generateCRIImagesConfig() map[string]any {
+	cfg := map[string]any{
+		"image_pull_progress_timeout": "2m0s",
+		"pinned_images": map[string]any{
+			"sandbox": types.DefaultSandboxImage,
 		},
+		"registry": map[string]any{
+			"config_path": s.containerdRegistryConfigDir,
+		},
+	}
 
-		"timeouts": map[string]any{
-			"io.containerd.timeout.bolt.open":         "0s",
-			"io.containerd.timeout.metrics.shimstats": "2s",
-			"io.containerd.timeout.shim.cleanup":      "5s",
-			"io.containerd.timeout.shim.load":         "5s",
-			"io.containerd.timeout.shim.shutdown":     "3s",
-			"io.containerd.timeout.task.state":        "2s",
-		},
+	if !s.fullMode {
+		cfg["max_concurrent_downloads"] = 1
+		cfg["stats_collect_period"] = 120
+	}
+
+	return cfg
+}
+
+// generateGCSchedulerConfig returns the GC scheduler plugin configuration.
+// Edge-specific overrides are only applied when not in full mode.
+func (s *service) generateGCSchedulerConfig() map[string]any {
+	if s.fullMode {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"pause_threshold":    0.01,
+		"deletion_threshold": 0,
+		"mutation_threshold": 50,
+		"schedule_delay":     "5s",
+		"startup_delay":      "200ms",
 	}
 }
 

--- a/pkg/runtime/containerd/service.go
+++ b/pkg/runtime/containerd/service.go
@@ -28,6 +28,7 @@ type service struct {
 	sandboxImageFile              string
 	localPathProvisionerImageFile string
 	isPortainerEdge               bool
+	fullMode                      bool
 }
 
 // NewService creates a new containerd service
@@ -51,5 +52,6 @@ func NewService(ctx context.Context, cancel context.CancelFunc, containerdReady 
 		sandboxImageFile:              embedded.SandboxImageFile,
 		localPathProvisionerImageFile: embedded.LocalPathProvisionerImageFile,
 		isPortainerEdge:               embedded.IsPortainerEdge,
+		fullMode:                      embedded.FullMode,
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -129,6 +129,9 @@ type Embedded struct {
 
 	// Portainer Edge
 	IsPortainerEdge bool
+
+	// Full mode — disables memory-saving overrides, uses upstream Kubernetes defaults
+	FullMode bool
 }
 
 // EdgeAgentConfig contains configuration for Portainer Edge Agent


### PR DESCRIPTION
…KS-49)

Introduce a --full mode flag (KUBESOLO_FULL env var) that disables edge-optimised overrides and uses upstream Kubernetes defaults for all component configurations. This enables running KubeSolo in CI/testing environments with standard Kubernetes behaviour.

Flag plumbing:
- Add Full flag to internal/config/flags with KUBESOLO_FULL env var
- Add FullMode to types.Embedded, wire through all 5 services
- Log active profile ("edge" or "full") at startup

Edge/full mode guards across all components:
- apiserver: etcd metrics, request throttling, timeouts, profiling, admission plugins, audit logging
- controller: profiling, GC threshold, sync concurrency, sync periods, API QPS/burst
- kubelet: profiling/debug handlers, frequencies, image GC, eviction thresholds, resource reservations, max pods
- kubeproxy: profiling, conntrack limits, sync period
- containerd: concurrent downloads, stats collection, GC scheduler

Remove flags and config values that duplicate upstream defaults:
- apiserver: secure-port, bind-address, enable-bootstrap-token-auth, etcd-compaction-interval, watch-cache, event-ttl, enable-garbage-collector
- controller: bind-address, secure-port, v, concurrent-daemonset-syncs, min-resync-period
- kubelet: enableServer, imageServiceEndpoint, registerNode, port, serializeImagePulls, registerWithTaints, imagePullProgressDeadline, RotateKubeletServerCertificate, imageGCLowThresholdPercent, registryPullQPS, registryBurst
- kubeproxy: iptables-masquerade-bit
- containerd: ~50 default-matching keys across CRI runtime, CRI images, grpc.v1.cri, overlayfs snapshotter, cgroup, and timeouts sections