### PR TITLE
fix(containerd): suppress false-positive runc warning when using crun

### DIFF
--- a/build/download-deps.sh
+++ b/build/download-deps.sh
@@ -12,6 +12,7 @@ PORTAINER_AGENT_VERSION="2.39.2"
 COREDNS_VERSION="1.14.3"
 LOCAL_PATH_PROVISIONER_VERSION="v0.0.36"
 PAUSE_IMAGE_VERSION="3.10"
+CRANE_VERSION="v0.21.5"
 
 # Offline mode embeds all OCI images; online mode (default) skips optional images
 OFFLINE=false
@@ -161,8 +162,7 @@ done
 # Download container images
 echo "Checking if Crane is available..."
 if ! command -v crane &> /dev/null; then
-    VERSION=$(curl -s "https://api.github.com/repos/google/go-containerregistry/releases/latest" | jq -r '.tag_name')
-    curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
+    curl -sL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
     tar -zxvf go-containerregistry.tar.gz -C /usr/local/bin/ crane
     rm -f go-containerregistry.tar.gz
 fi

--- a/internal/core/embedded/load.go
+++ b/internal/core/embedded/load.go
@@ -32,6 +32,19 @@ func loadContainerdComponents(embedded types.Embedded) error {
 			return fmt.Errorf("failed to extract %s binary: %v", binary.name, err)
 		}
 	}
+
+	// Symlink containerd-shim-runc-v2 alongside the kubesolo binary.
+	// containerd's resolveRuntimePath falls back to checking filepath.Dir(os.Executable())
+	// for shim binaries, so placing the shim there lets it be found without PATH manipulation.
+	selfPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to resolve kubesolo executable path: %w", err)
+	}
+	shimLink := filepath.Join(filepath.Dir(selfPath), "containerd-shim-runc-v2")
+	if err := filesystem.EnsureSymbolicLink(embedded.ContainerdShimBinaryFile, shimLink); err != nil {
+		return fmt.Errorf("failed to create containerd-shim-runc-v2 symlink: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/runtime/filesystem/file.go
+++ b/internal/runtime/filesystem/file.go
@@ -25,11 +25,11 @@ func EnsureDirectoryExists(path string) error {
 // it returns an error if it fails
 func EnsureSymbolicLink(source, target string) error {
 	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing target CNI config %s: %v", target, err)
+		return fmt.Errorf("failed to remove existing symlink %s: %v", target, err)
 	}
 
 	if err := os.Symlink(source, target); err != nil {
-		return fmt.Errorf("failed to create symlink for CNI config %s: %v", target, err)
+		return fmt.Errorf("failed to create symlink %s: %v", target, err)
 	}
 	return nil
 }

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -74,7 +74,6 @@ func (s *service) generateContainerdConfig() map[string]any {
 					"runtimes": map[string]any{
 						"crun": map[string]any{
 							"runtime_type": "io.containerd.runc.v2",
-							"runtime_path": s.containerdShimBinaryFile,
 							"options": map[string]any{
 								"BinaryName":    s.crunBinaryFile,
 								"SystemdCgroup": useSystemdCgroup(),


### PR DESCRIPTION
When runtime_path was set in the containerd CRI config, containerd passed the full shim path as opts.Runtime, bypassing the known-shim optimisation in loadShimInfo (shim_manager.go). This caused getRuntimeInfo to probe the shim with `containerd-shim-runc-v2 -info`, which internally called exec.LookPath("runc") — failing because only crun is present.

Fix by removing runtime_path from the crun runtime handler. Without it, opts.Runtime stays as "io.containerd.runc.v2", which matches containerd's known-shim skip and prevents the probe entirely.

To allow containerd's resolveRuntimePath to still locate the shim binary, a symlink is created alongside the kubesolo executable at startup. containerd's own fallback in resolveRuntimePath checks filepath.Dir(os.Executable()) for shim binaries when PATH lookup fails.