### PR TITLE
fix(containerd): use fuse-overlayfs when rootfs is an overlay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/containerd/containerd/v2 v2.2.3
+	github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.7
 	github.com/k3s-io/kine v0.14.16
 	github.com/klauspost/compress v1.18.5
 	github.com/mattn/go-sqlite3 v1.14.40
@@ -12,6 +13,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cobra v1.9.1
 	github.com/urfave/cli/v2 v2.27.7
+	golang.org/x/sys v0.42.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
@@ -219,7 +221,6 @@ require (
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
+github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.7 h1:pD+wZQE81lBgjiQRaDMJYd9k9k/Xc90eKNpZho1r2tI=
+github.com/containerd/fuse-overlayfs-snapshotter/v2 v2.1.7/go.mod h1:gzkTvoDZmX6hLuNn6qQ8s3wkTJ+Va9SbT76v07GzVK0=
 github.com/containerd/go-cni v1.1.13 h1:eFSGOKlhoYNxpJ51KRIMHZNlg5UgocXEIEBGkY7Hnis=
 github.com/containerd/go-cni v1.1.13/go.mod h1:nTieub0XDRmvCZ9VI/SBG6PyqT95N4FIhxsauF1vSBI=
 github.com/containerd/go-runc v1.1.0 h1:OX4f+/i2y5sUT7LhmcJH7GYrjjhHa1QI4e8yO0gGleA=

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -1,13 +1,86 @@
 package containerd
 
 import (
+	"errors"
+	"io/fs"
 	"os"
+	"os/exec"
+	"path/filepath"
 
 	"github.com/pelletier/go-toml"
 	"github.com/portainer/kubesolo/types"
 	"github.com/rs/zerolog/log"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/sys/unix"
 )
+
+// overlayfsSuperMagic is the statfs magic for OverlayFS.
+const overlayfsSuperMagic = 0x794c7630
+
+// Snapshotter names used by containerd.
+const (
+	snapshotterOverlayfs     = "overlayfs"
+	snapshotterFuseOverlayfs = "fuse-overlayfs"
+	snapshotterNative        = "native"
+)
+
+// pickSnapshotter chooses a containerd snapshotter that works on the
+// filesystem hosting the containerd root.
+//
+//   - On a normal host, returns "overlayfs" (kernel overlay, fastest).
+//   - When the containerd root is itself on an overlay filesystem (e.g.
+//     FriendlyElec/Alpine images on RK35xx), kernel overlay-on-overlay
+//     returns EINVAL from mount(2). In that case it prefers
+//     "fuse-overlayfs" (userspace overlay, same CoW semantics), but only
+//     if the `fuse-overlayfs` binary is present in PATH. If it is not,
+//     falls back to "native" with a warning — native copies layers
+//     instead of stacking them, so it's slow but works everywhere.
+//
+// Returning "overlayfs" is also used as the safe default whenever the
+// detection itself fails (permission denied, I/O error, statfs error),
+// because most hosts use overlayfs successfully.
+func pickSnapshotter(rootDir string) string {
+	target := rootDir
+	if _, err := os.Stat(target); err != nil {
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			// Root dir doesn't exist yet (first start). Inspect the parent
+			// since containerd will create the dir on the same filesystem.
+			target = filepath.Dir(target)
+		default:
+			log.Warn().Str("component", "containerd").Err(err).
+				Str("path", target).
+				Msgf("stat failed; defaulting to %s snapshotter", snapshotterOverlayfs)
+			return snapshotterOverlayfs
+		}
+	}
+
+	var st unix.Statfs_t
+	if err := unix.Statfs(target, &st); err != nil {
+		log.Warn().Str("component", "containerd").Err(err).
+			Str("path", target).
+			Msgf("statfs failed; defaulting to %s snapshotter", snapshotterOverlayfs)
+		return snapshotterOverlayfs
+	}
+	if uint32(st.Type) != overlayfsSuperMagic {
+		return snapshotterOverlayfs
+	}
+
+	// Containerd root is on an overlay. Prefer fuse-overlayfs, but only
+	// when its userspace helper is actually installed on the host —
+	// containerd would otherwise fail at the first snapshot operation
+	// with an opaque "fuse-overlayfs: executable file not found" error.
+	if _, err := exec.LookPath("fuse-overlayfs"); err != nil {
+		log.Warn().Str("component", "containerd").
+			Msgf("containerd root is on overlay but fuse-overlayfs binary not found in PATH; "+
+				"falling back to %s snapshotter (slower; install fuse-overlayfs for normal performance)",
+				snapshotterNative)
+		return snapshotterNative
+	}
+	log.Info().Str("component", "containerd").
+		Msgf("containerd root is on overlay; using %s snapshotter", snapshotterFuseOverlayfs)
+	return snapshotterFuseOverlayfs
+}
 
 // isCgroupV2 returns true if the host uses the cgroupv2 unified hierarchy.
 // When true, crun must use the systemd cgroup driver (SystemdCgroup=true)
@@ -56,6 +129,7 @@ func (s *service) writeContainerdConfigFile() error {
 
 // generateConfig generates the containerd config
 func (s *service) generateContainerdConfig() map[string]any {
+	snapshotter := pickSnapshotter(s.containerdRootDir)
 	return map[string]any{
 		"version": 3,
 		"root":    s.containerdRootDir,
@@ -74,6 +148,7 @@ func (s *service) generateContainerdConfig() map[string]any {
 					"runtimes": map[string]any{
 						"crun": map[string]any{
 							"runtime_type": "io.containerd.runc.v2",
+							"snapshotter":  snapshotter,
 							"options": map[string]any{
 								"BinaryName":    s.crunBinaryFile,
 								"SystemdCgroup": useSystemdCgroup(),
@@ -99,6 +174,10 @@ func (s *service) generateContainerdConfig() map[string]any {
 // generateCRIImagesConfig returns the CRI images plugin configuration.
 // Edge-specific overrides (max_concurrent_downloads, stats_collect_period) are
 // only applied when not in full mode.
+//
+// Note: the snapshotter is configured per-runtime in
+// generateContainerdConfig (under runtimes.crun); the CRI images plugin
+// inherits that selection for unpack operations, so no setting is needed here.
 func (s *service) generateCRIImagesConfig() map[string]any {
 	cfg := map[string]any{
 		"image_pull_progress_timeout": "2m0s",

--- a/pkg/runtime/containerd/plugins.go
+++ b/pkg/runtime/containerd/plugins.go
@@ -29,6 +29,8 @@ import (
 	_ "github.com/containerd/containerd/v2/plugins/services/tasks"
 	_ "github.com/containerd/containerd/v2/plugins/services/version"
 	_ "github.com/containerd/containerd/v2/plugins/services/warning"
+	_ "github.com/containerd/containerd/v2/plugins/snapshots/native/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/snapshots/overlay/plugin"
+	_ "github.com/containerd/fuse-overlayfs-snapshotter/v2/plugin"
 	_ "github.com/containerd/containerd/v2/plugins/transfer"
 )


### PR DESCRIPTION
Detect the overlay-on-overlay case at config generation by statfs'ing the containerd root and checking for OVERLAYFS_SUPER_MAGIC (0x794c7630). When detected, select the `fuse-overlayfs` snapshotter for the crun runtime; otherwise keep using kernel overlays