### PR TITLE
fix(components): prevent exit on optional deploy failure and let Portainer manage agent [KS-33]

### DIFF
--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -273,7 +273,7 @@ func (s *kubesolo) run() {
 	if s.localStorage {
 		log.Info().Str("component", "kubesolo").Msg("deploying local path...")
 		if err := localpath.Deploy(s.embedded.AdminKubeconfigFile, s.embedded.LocalPathStorageDir, s.localStorageSharedPath); err != nil {
-			log.Fatal().Err(err).Msg("failed to deploy local path")
+			log.Error().Err(err).Msg("failed to deploy local path, continuing without it")
 		}
 	}
 
@@ -285,7 +285,7 @@ func (s *kubesolo) run() {
 			EdgeAsync:        s.portainerEdgeAsync,
 			EdgeInsecurePoll: "true",
 		}); err != nil {
-			log.Fatal().Err(err).Msg("failed to deploy portainer edge agent...")
+			log.Error().Err(err).Msg("failed to deploy portainer edge agent, continuing without it")
 		}
 	}
 
@@ -296,7 +296,7 @@ func (s *kubesolo) run() {
 			Image:     types.DefaultD2KImage,
 			Certs:     s.embedded.D2KCerts,
 		}); err != nil {
-			log.Fatal().Err(err).Msg("failed to deploy d2k")
+			log.Error().Err(err).Msg("failed to deploy d2k, continuing without it")
 		}
 
 	}

--- a/pkg/components/portainer/configuration.go
+++ b/pkg/components/portainer/configuration.go
@@ -33,16 +33,11 @@ func createConfigMap(ctx context.Context, clientset *kubernetes.Clientset, confi
 		Data: data,
 	}
 
+	// Create only if absent. On reboot the ConfigMap is restored from kine, so
+	// we leave it untouched to preserve any Portainer-managed changes.
 	_, err := clientset.CoreV1().ConfigMaps(PortainerNamespace).Create(ctx, configMap, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
-	}
-
-	if errors.IsAlreadyExists(err) {
-		_, err = clientset.CoreV1().ConfigMaps(PortainerNamespace).Update(ctx, configMap, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -59,16 +54,11 @@ func createSecret(ctx context.Context, clientset *kubernetes.Clientset, edgeKey 
 		},
 	}
 
+	// Create only if absent. On reboot the Secret is restored from kine, so we
+	// leave it untouched to preserve any Portainer-managed changes.
 	_, err := clientset.CoreV1().Secrets(PortainerNamespace).Create(ctx, secret, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
-	}
-
-	if errors.IsAlreadyExists(err) {
-		_, err = clientset.CoreV1().Secrets(PortainerNamespace).Update(ctx, secret, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/pkg/components/portainer/deployment.go
+++ b/pkg/components/portainer/deployment.go
@@ -116,16 +116,12 @@ func createDeployment(ctx context.Context, clientset *kubernetes.Clientset, conf
 		},
 	}
 
+	// Create the deployment only if it does not already exist. On reboot the
+	// deployment is restored from kine, so we must not overwrite it — doing so
+	// would revert any Portainer-managed agent version back to the default.
 	_, err := clientset.AppsV1().Deployments(PortainerNamespace).Create(ctx, deployment, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
-	}
-
-	if errors.IsAlreadyExists(err) {
-		_, err = clientset.AppsV1().Deployments(PortainerNamespace).Update(ctx, deployment, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/components/portainer/rbac.go
+++ b/pkg/components/portainer/rbac.go
@@ -44,16 +44,11 @@ func createClusterRoleBinding(ctx context.Context, clientset *kubernetes.Clients
 		},
 	}
 
+	// Create only if absent. On reboot the ClusterRoleBinding is restored from
+	// kine, so we leave it untouched to preserve any Portainer-managed changes.
 	_, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, clusterRoleBinding, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
-	}
-
-	if errors.IsAlreadyExists(err) {
-		_, err = clientset.RbacV1().ClusterRoleBindings().Update(ctx, clusterRoleBinding, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/pkg/components/portainer/service.go
+++ b/pkg/components/portainer/service.go
@@ -36,16 +36,11 @@ func createHeadlessService(ctx context.Context, clientset *kubernetes.Clientset)
 		},
 	}
 
+	// Create only if absent. On reboot the Service is restored from kine, so we
+	// leave it untouched to preserve any Portainer-managed changes.
 	_, err := clientset.CoreV1().Services(PortainerNamespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
-	}
-
-	if errors.IsAlreadyExists(err) {
-		_, err = clientset.CoreV1().Services(PortainerNamespace).Update(ctx, service, metav1.UpdateOptions{})
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
KubeSolo exited via log.Fatal when `local-path-provisioner`, the Portainer edge agent, or `d2k` failed to deploy, taking down an otherwise healthy cluster. These deploys now log an error and continue; only `coredns` remains fatal.

The Portainer Agent manifests were reconciled with Create+Update on every boot, so they were restored from kine and then overwritten with the baked-in defaults — reverting any Portainer-managed agent version on reboot. All Portainer Agent resources (Deployment, ConfigMap, Secret, ClusterRoleBinding, Service) are now create-only, so Portainer-managed changes persist across reboots.

Note: edge config (EDGE_ID/EDGE_KEY/EDGE_ASYNC) no longer reconciles from flags after first boot.