### PR TITLE
fix(containerd): support immutable root filesystems

### DIFF
--- a/internal/core/embedded/load.go
+++ b/internal/core/embedded/load.go
@@ -33,18 +33,6 @@ func loadContainerdComponents(embedded types.Embedded) error {
 		}
 	}
 
-	// Symlink containerd-shim-runc-v2 alongside the kubesolo binary.
-	// containerd's resolveRuntimePath falls back to checking filepath.Dir(os.Executable())
-	// for shim binaries, so placing the shim there lets it be found without PATH manipulation.
-	selfPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to resolve kubesolo executable path: %w", err)
-	}
-	shimLink := filepath.Join(filepath.Dir(selfPath), "containerd-shim-runc-v2")
-	if err := filesystem.EnsureSymbolicLink(embedded.ContainerdShimBinaryFile, shimLink); err != nil {
-		return fmt.Errorf("failed to create containerd-shim-runc-v2 symlink: %w", err)
-	}
-
 	return nil
 }
 

--- a/internal/runtime/filesystem/file.go
+++ b/internal/runtime/filesystem/file.go
@@ -21,15 +21,18 @@ func EnsureDirectoryExists(path string) error {
 	return nil
 }
 
-// EnsureSymbolicLink removes the existing target and creates a new symbolic link
-// it returns an error if it fails
+// EnsureSymbolicLink preserves a correct link and replaces any other target.
 func EnsureSymbolicLink(source, target string) error {
+	if destination, err := os.Readlink(target); err == nil && destination == source {
+		return nil
+	}
+
 	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove existing symlink %s: %v", target, err)
+		return fmt.Errorf("failed to replace symlink %s with %s: %w", target, source, err)
 	}
 
 	if err := os.Symlink(source, target); err != nil {
-		return fmt.Errorf("failed to create symlink %s: %v", target, err)
+		return fmt.Errorf("failed to install symlink %s -> %s: %w", target, source, err)
 	}
 	return nil
 }

--- a/internal/runtime/filesystem/file_test.go
+++ b/internal/runtime/filesystem/file_test.go
@@ -1,0 +1,98 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsureSymbolicLink(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source")
+	if err := os.WriteFile(source, []byte("test"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("absent destination on non-writable directory", func(t *testing.T) {
+		dir := nonWritableDir(t)
+		target := filepath.Join(dir, "link")
+		if err := EnsureSymbolicLink(source, target); err == nil {
+			t.Fatal("expected installation on a non-writable directory to fail")
+		}
+	})
+
+	t.Run("existing correct symlink on non-writable directory", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "link")
+		if err := os.Symlink(source, target); err != nil {
+			t.Fatal(err)
+		}
+		makeNonWritable(t, dir)
+		if err := EnsureSymbolicLink(source, target); err != nil {
+			t.Fatalf("correct symlink should be preserved: %v", err)
+		}
+	})
+
+	t.Run("existing incorrect symlink on non-writable directory", func(t *testing.T) {
+		dir := t.TempDir()
+		target := filepath.Join(dir, "link")
+		if err := os.Symlink(filepath.Join(dir, "wrong"), target); err != nil {
+			t.Fatal(err)
+		}
+		makeNonWritable(t, dir)
+		if err := EnsureSymbolicLink(source, target); err == nil {
+			t.Fatal("expected replacement on a non-writable directory to fail")
+		}
+	})
+
+	t.Run("absent destination on writable directory", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "link")
+		if err := EnsureSymbolicLink(source, target); err != nil {
+			t.Fatal(err)
+		}
+		assertLink(t, target, source)
+	})
+
+	t.Run("existing incorrect symlink on writable directory", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "link")
+		if err := os.Symlink("wrong", target); err != nil {
+			t.Fatal(err)
+		}
+		if err := EnsureSymbolicLink(source, target); err != nil {
+			t.Fatal(err)
+		}
+		assertLink(t, target, source)
+	})
+}
+
+func nonWritableDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	makeNonWritable(t, dir)
+	return dir
+}
+
+func makeNonWritable(t *testing.T, dir string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("directory mode bits do not enforce writability on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory mode bits")
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+}
+
+func assertLink(t *testing.T, target, source string) {
+	t.Helper()
+	destination, err := os.Readlink(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if destination != source {
+		t.Fatalf("link destination = %q, want %q", destination, source)
+	}
+}

--- a/pkg/runtime/containerd/config.go
+++ b/pkg/runtime/containerd/config.go
@@ -147,7 +147,8 @@ func (s *service) generateContainerdConfig() map[string]any {
 					"default_runtime_name": "crun",
 					"runtimes": map[string]any{
 						"crun": map[string]any{
-							"runtime_type": "io.containerd.runc.v2",
+							// An absolute runtime type is supported by containerd and avoids installing the shim in /usr/bin.
+							"runtime_type": s.containerdShimBinaryFile,
 							"snapshotter":  snapshotter,
 							"options": map[string]any{
 								"BinaryName":    s.crunBinaryFile,

--- a/pkg/runtime/containerd/config_test.go
+++ b/pkg/runtime/containerd/config_test.go
@@ -1,0 +1,39 @@
+package containerd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestGeneratedRuntimeTypeLaunchesEmbeddedShim(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "containerd-shim-runc-v2")
+	marker := filepath.Join(dir, "launched")
+	if err := os.WriteFile(shim, []byte("#!/bin/sh\nprintf launched > \"$1\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &service{
+		containerdRootDir:        t.TempDir(),
+		containerdShimBinaryFile: shim,
+	}
+	config := s.generateContainerdConfig()
+	plugins := config["plugins"].(map[string]any)
+	cri := plugins["io.containerd.cri.v1.runtime"].(map[string]any)
+	containerdConfig := cri["containerd"].(map[string]any)
+	runtimes := containerdConfig["runtimes"].(map[string]any)
+	crun := runtimes["crun"].(map[string]any)
+	runtimeType := crun["runtime_type"].(string)
+
+	if runtimeType != shim || !filepath.IsAbs(runtimeType) {
+		t.Fatalf("runtime_type = %q, want absolute embedded shim path %q", runtimeType, shim)
+	}
+	if err := exec.Command(runtimeType, marker).Run(); err != nil {
+		t.Fatalf("configured shim did not launch: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("configured shim did not run: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes KubeSolo startup on immutable Linux systems where `/usr` is mounted read-only.

KubeSolo previously extracted `containerd-shim-runc-v2` under `/var/lib/kubesolo/containerd`, then attempted to install a symlink beside the KubeSolo executable—typically under `/usr/bin`. This caused startup to fail on read-only root filesystems.

This PR:

- configures containerd to use the absolute path of the extracted shim under KubeSolo’s writable data directory;
- removes the runtime `/usr/bin/containerd-shim-runc-v2` symlink installation;
- preserves an existing correct symlink in the shared symlink helper;
- returns clearer errors when an incorrect link cannot be replaced;
- adds focused tests for writable and non-writable destinations and shim launch behavior.

## Testing

- Filesystem symlink tests pass, covering absent, correct, and incorrect destinations on writable and non-writable directories.
- The generated containerd runtime path and shim launch test passes on Linux/amd64.
- Formatting and diff checks pass.

Fixes #170