### PR TITLE
fix(build): exclude embedded artifacts from external deps builds

### DIFF
--- a/internal/core/embedded/embedded.go
+++ b/internal/core/embedded/embedded.go
@@ -1,4 +1,4 @@
-//go:build (linux && amd64) || (linux && arm64) || (linux && arm)
+//go:build !external_deps && linux && (amd64 || arm64 || arm)
 
 package embedded
 

--- a/internal/core/embedded/embedded_d2k_offline_supported.go
+++ b/internal/core/embedded/embedded_d2k_offline_supported.go
@@ -1,4 +1,4 @@
-//go:build offline && (amd64 || arm64)
+//go:build !external_deps && offline && (amd64 || arm64)
 
 package embedded
 

--- a/internal/core/embedded/embedded_d2k_offline_unsupported.go
+++ b/internal/core/embedded/embedded_d2k_offline_unsupported.go
@@ -1,4 +1,4 @@
-//go:build offline && !amd64 && !arm64
+//go:build !external_deps && offline && !amd64 && !arm64
 
 package embedded
 

--- a/internal/core/embedded/embedded_external.go
+++ b/internal/core/embedded/embedded_external.go
@@ -1,0 +1,18 @@
+//go:build external_deps
+
+package embedded
+
+// External-dependency builds use artifacts supplied by the host.
+var (
+	containerdShimBinary          []byte
+	crunBinary                    []byte
+	cniPluginBridge               []byte
+	cniPluginHostLocal            []byte
+	cniPluginPortmap              []byte
+	cniPluginLoopback             []byte
+	corednsImageFile              []byte
+	sandboxImageFile              []byte
+	portainerEdgeImageFile        []byte
+	localPathProvisionerImageFile []byte
+	d2kImageFile                  []byte
+)

--- a/internal/core/embedded/embedded_images_offline.go
+++ b/internal/core/embedded/embedded_images_offline.go
@@ -1,4 +1,4 @@
-//go:build offline && !riscv64
+//go:build !external_deps && offline && !riscv64
 
 package embedded
 

--- a/internal/core/embedded/embedded_images_offline_riscv64.go
+++ b/internal/core/embedded/embedded_images_offline_riscv64.go
@@ -1,4 +1,4 @@
-//go:build offline && riscv64
+//go:build !external_deps && offline && riscv64
 
 package embedded
 

--- a/internal/core/embedded/embedded_images_online.go
+++ b/internal/core/embedded/embedded_images_online.go
@@ -1,4 +1,4 @@
-//go:build !offline
+//go:build !external_deps && !offline
 
 package embedded
 

--- a/internal/core/embedded/embedded_riscv64.go
+++ b/internal/core/embedded/embedded_riscv64.go
@@ -1,4 +1,4 @@
-//go:build linux && riscv64
+//go:build !external_deps && linux && riscv64
 
 package embedded
 


### PR DESCRIPTION
Add `external_deps` build constraints to files containing embedded runtime artifacts so these files are not required when building against host-provided dependencies.

Provide empty artifact declarations for `external_deps` builds, allowing the shared embedded package to compile without downloading containerd, CNI plugins, or container images.


Build can be tested à la:
```sh
go build -trimpath -buildmode=pie -tags external_deps -o kubesolo ./cmd/kubesolo
```