### PR TITLE
fix(runtime): make KubeSolo work on nftables-only and read-only /proc/sys hosts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,5 @@
 build/
 examples/
 assets/
-dist/
+dist/*
 !dist/kubesolo

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM alpine:3.21
 RUN apk add --no-cache \
     iptables \
     ip6tables \
+    nftables \
     conntrack-tools \
     iproute2 \
     kmod \

--- a/Makefile
+++ b/Makefile
@@ -157,10 +157,53 @@ else
 	@exit 1
 endif
 
+# ---------- Container runtime ----------
+#
+# Targets that shell out to a container engine work with either Apple
+# Containers (`container`) or Docker. The engine is auto-detected, preferring
+# `container` when it is on PATH; override with CONTAINER_RUNTIME=docker.
+CONTAINER_RUNTIME ?= $(if $(shell command -v container 2>/dev/null),container,docker)
+
+# Apple Containers points the guest at the vmnet gateway (192.168.64.1) as its
+# resolver, which refuses queries on some hosts — every `apk add` and module
+# fetch inside the container then fails with a DNS error. Pin a resolver for
+# `container` invocations. Override CONTAINER_DNS to use your own resolver
+# (needed behind a split-horizon or VPN DNS), or set it empty to fall back to
+# the engine default. Docker resolves through its own daemon, so it is left
+# alone.
+CONTAINER_DNS ?= 1.1.1.1
+
+# Apple Containers gives each container 1 GiB and 4 CPUs. That is not enough to
+# compile this tree — the Go compiler gets OOM-killed part-way through with
+# "compile: signal: killed" — so raise both. Docker shares one large VM sized by
+# the user, so it is left alone. Set either variable empty to use the engine
+# default.
+CONTAINER_MEMORY ?= 8g
+CONTAINER_CPUS ?= 8
+
+ifeq ($(CONTAINER_RUNTIME),docker)
+CONTAINER_DNS_FLAG =
+CONTAINER_RESOURCE_FLAGS =
+else
+CONTAINER_DNS_FLAG = $(if $(CONTAINER_DNS),--dns $(CONTAINER_DNS))
+CONTAINER_RESOURCE_FLAGS = $(if $(CONTAINER_MEMORY),--memory $(CONTAINER_MEMORY)) $(if $(CONTAINER_CPUS),--cpus $(CONTAINER_CPUS))
+endif
+
+CONTAINER_RUN_FLAGS = $(CONTAINER_DNS_FLAG) $(CONTAINER_RESOURCE_FLAGS)
+
+# Docker needs buildx to honour --platform; `container build` takes it
+# natively. Both engines spell the push the same way.
+ifeq ($(CONTAINER_RUNTIME),docker)
+IMAGE_BUILD = docker buildx build
+else
+IMAGE_BUILD = $(CONTAINER_RUNTIME) build $(CONTAINER_DNS_FLAG)
+endif
+IMAGE_PUSH = $(CONTAINER_RUNTIME) image push
+
 .PHONY: build-using-image
 build-using-image:
 	mkdir -p $(HOME)/.go-cache/mod $(HOME)/.go-cache/build
-	docker run --platform $(GOOS)/$(GOARCH) --workdir /app --rm \
+	$(CONTAINER_RUNTIME) run $(CONTAINER_RUN_FLAGS) --platform $(GOOS)/$(GOARCH) --workdir /app --rm \
 		-v ${PWD}:/app \
 		-v ${HOME}/.go-cache/mod:/go/pkg/mod \
 		-v ${HOME}/.go-cache/build:/root/.cache/go-build \
@@ -173,7 +216,7 @@ build-using-image:
 .PHONY: build-using-alpine
 build-using-alpine:
 	mkdir -p $(HOME)/.go-cache/mod $(HOME)/.go-cache/build
-	docker run --platform $(GOOS)/$(GOARCH) --workdir /app --rm \
+	$(CONTAINER_RUNTIME) run $(CONTAINER_RUN_FLAGS) --platform $(GOOS)/$(GOARCH) --workdir /app --rm \
 		-v ${PWD}:/app \
 		-v ${HOME}/.go-cache/mod:/go/pkg/mod \
 		-v ${HOME}/.go-cache/build:/root/.cache/go-build \
@@ -302,22 +345,44 @@ clean-kubesoloctl:
 IMAGE_NAME ?= portainer/kubesolo
 IMAGE_TAG ?= $(VERSION)
 
+# Apple Containers will not push a reference without a registry host ("could
+# not extract host from reference"); Docker assumes docker.io. Qualify
+# IMAGE_NAME for `container` when it carries no host of its own — a name whose
+# first segment holds a "." or ":" (ghcr.io/..., localhost:5000/...) already
+# does and is left as-is.
+IMAGE_NAME_HEAD = $(firstword $(subst /, ,$(IMAGE_NAME)))
+ifeq ($(CONTAINER_RUNTIME),docker)
+IMAGE_REF = $(IMAGE_NAME)
+else
+IMAGE_REF = $(if $(or $(findstring .,$(IMAGE_NAME_HEAD)),$(findstring :,$(IMAGE_NAME_HEAD))),$(IMAGE_NAME),docker.io/$(IMAGE_NAME))
+endif
+
 # Build the container image (downloads arch-specific deps, builds static binary via Alpine, then packages it)
 .PHONY: image
 image: deps build-using-alpine
-	docker buildx build \
+	$(IMAGE_BUILD) \
 		--platform $(GOOS)/$(GOARCH) \
-		-t $(IMAGE_NAME):$(IMAGE_TAG)-$(GOOS)-$(GOARCH) .
+		-t $(IMAGE_REF):$(IMAGE_TAG)-$(GOOS)-$(GOARCH) .
 
-# Build multi-arch container images using buildx
+# Build and push the container image for $(GOOS)/$(GOARCH). buildx builds and
+# pushes in one step; `container` builds one platform at a time and pushes
+# afterwards, so multi-arch manifests need one invocation per architecture.
 .PHONY: image-buildx
 image-buildx:
+ifeq ($(CONTAINER_RUNTIME),docker)
 	docker buildx build --platform $(GOOS)/$(GOARCH) \
-		-t $(IMAGE_NAME):$(IMAGE_TAG) -t $(IMAGE_NAME):latest \
+		-t $(IMAGE_REF):$(IMAGE_TAG) -t $(IMAGE_REF):latest \
 		--push .
+else
+	$(IMAGE_BUILD) --platform $(GOOS)/$(GOARCH) \
+		-t $(IMAGE_REF):$(IMAGE_TAG) .
+	$(CONTAINER_RUNTIME) image tag $(IMAGE_REF):$(IMAGE_TAG) $(IMAGE_REF):latest
+	$(IMAGE_PUSH) $(IMAGE_REF):$(IMAGE_TAG)
+	$(IMAGE_PUSH) $(IMAGE_REF):latest
+endif
 
 # Push the container image
 .PHONY: image-push
 image-push:
-	docker push $(IMAGE_NAME):$(IMAGE_TAG)
-	docker push $(IMAGE_NAME):latest
+	$(IMAGE_PUSH) $(IMAGE_REF):$(IMAGE_TAG)
+	$(IMAGE_PUSH) $(IMAGE_REF):latest

--- a/cmd/kubesolo/main.go
+++ b/cmd/kubesolo/main.go
@@ -227,7 +227,7 @@ func (s *kubesolo) run() {
 		{
 			name: "apiserver",
 			start: func() {
-				apiserverService := apiserver.NewService(ctx, cancel, apiServerReadyCh, s.hostName, s.embedded)
+				apiserverService := apiserver.NewService(ctx, cancel, apiServerReadyCh, s.embedded.NodeName, s.embedded)
 				s.wg.Go(func() {
 					_ = apiserverService.Run(kineReadyCh)
 				})
@@ -570,5 +570,6 @@ func (s *kubesolo) bootstrap() {
 		MTUPinned:       mtuPinned,
 		ContainerMode:   containerMode,
 		RuntimeEndpoint: s.runtimeEndpoint,
+		Hostname:        s.hostName,
 	})
 }

--- a/docs/configuration/config-file.md
+++ b/docs/configuration/config-file.md
@@ -153,6 +153,7 @@ kind: Config
 path: /var/lib/kubesolo
 
 kubernetes:
+  nodeName: ""            # empty = the hostname
   apiServer:
     extraSANs: []
     startupTimeoutSeconds: 600
@@ -225,6 +226,7 @@ and stays at the top level.
 | `kubernetes.kubelet.cpuManager.policyOptions` | `object` | `map[]` |
 | `kubernetes.kubelet.cpuManager.reservedCPUs` | `string` | `""` |
 | `kubernetes.kubelet.systemReserved` | `object` | `map[]` |
+| `kubernetes.nodeName` | `string` | `""` |
 | `logging.debug` | `boolean` | `false` |
 | `logging.pprof` | `boolean` | `false` |
 | `metrics.bindAddress` | `string` | `127.0.0.1:9105` |

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -35,6 +35,7 @@ func Defaults() *types.Config {
 		},
 
 		Kubernetes: types.KubernetesConfig{
+			NodeName: "", // the hostname
 			APIServer: types.APIServerConfig{
 				ExtraSANs:             nil,
 				StartupTimeoutSeconds: types.DefaultStartupTimeout,

--- a/internal/config/embedded.go
+++ b/internal/config/embedded.go
@@ -9,6 +9,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/portainer/kubesolo/internal/runtime/cri"
 	"github.com/portainer/kubesolo/types"
@@ -43,10 +44,15 @@ func BuildEmbedded(cfg *types.Config, probe Probe) types.Embedded {
 		runtimeEndpoint = cri.Embedded(containerdSocketFile)
 	}
 
-	// The node this control plane manages. Configured explicitly when a
-	// host-managed kubelet registers under a name this host does not share,
-	// otherwise the hostname, which is what KubeSolo's own kubelet registers as.
-	nodeName := cfg.Kubernetes.NodeName
+	// The node this control plane manages, defaulting to the hostname.
+	//
+	// Trimmed and lowercased to match what the kubelet does to --hostname-override
+	// before registering. Without this a configured "Talos-CP-1" would register a
+	// node called "talos-cp-1" while the NodeSetter webhook and the kubelet's
+	// certificate subject kept the original spelling, and every pod would be
+	// pinned to a node that does not exist. probe.Hostname is already normalised
+	// by system.GetHostname.
+	nodeName := strings.ToLower(strings.TrimSpace(cfg.Kubernetes.NodeName))
 	if nodeName == "" {
 		nodeName = probe.Hostname
 	}

--- a/internal/config/embedded.go
+++ b/internal/config/embedded.go
@@ -17,6 +17,9 @@ import (
 // Probe carries what the host reported and BuildEmbedded cannot work out for
 // itself. Everything else it needs comes from the configuration.
 type Probe struct {
+	// Hostname is the host's name, the fallback for kubernetes.nodeName.
+	Hostname string
+
 	NodeIP         string
 	NodeIPPinned   bool
 	LoadBalancerIP string
@@ -40,7 +43,17 @@ func BuildEmbedded(cfg *types.Config, probe Probe) types.Embedded {
 		runtimeEndpoint = cri.Embedded(containerdSocketFile)
 	}
 
+	// The node this control plane manages. Configured explicitly when a
+	// host-managed kubelet registers under a name this host does not share,
+	// otherwise the hostname, which is what KubeSolo's own kubelet registers as.
+	nodeName := cfg.Kubernetes.NodeName
+	if nodeName == "" {
+		nodeName = probe.Hostname
+	}
+
 	return types.Embedded{
+		NodeName: nodeName,
+
 		// System Node IP
 		NodeIP:          probe.NodeIP,
 		NodeIPSpecified: probe.NodeIPPinned,

--- a/internal/config/embedded_test.go
+++ b/internal/config/embedded_test.go
@@ -117,6 +117,13 @@ func goldenCases() []goldenCase {
 			probe: Probe{Hostname: "kubesolo-container"},
 		},
 		{
+			name: "node-name-normalised",
+			cfg: cfgWith(at(base), func(c *types.Config) {
+				c.Kubernetes.NodeName = "  Talos-CP-1  "
+			}),
+			probe: Probe{Hostname: "kubesolo-container"},
+		},
+		{
 			name:  "node-name-falls-back-to-hostname",
 			cfg:   cfgWith(at(base)),
 			probe: Probe{Hostname: "edge-box-7"},

--- a/internal/config/embedded_test.go
+++ b/internal/config/embedded_test.go
@@ -109,6 +109,18 @@ func goldenCases() []goldenCase {
 			}
 			c.Kubernetes.Kubelet.SystemReserved = map[string]string{"cpu": "1", "memory": "500Mi"}
 		})},
+		{
+			name: "node-name-explicit",
+			cfg: cfgWith(at(base), func(c *types.Config) {
+				c.Kubernetes.NodeName = "talos-cp-1"
+			}),
+			probe: Probe{Hostname: "kubesolo-container"},
+		},
+		{
+			name:  "node-name-falls-back-to-hostname",
+			cfg:   cfgWith(at(base)),
+			probe: Probe{Hostname: "edge-box-7"},
+		},
 		{name: "metrics-enabled", cfg: cfgWith(at(base), func(c *types.Config) {
 			c.Metrics = types.MetricsConfig{Enabled: true, BindAddress: "0.0.0.0:9105"}
 		})},

--- a/internal/config/registry.go
+++ b/internal/config/registry.go
@@ -151,6 +151,12 @@ func buildRegistry() []Field {
 			},
 		},
 		{
+			ConfigPath: "kubernetes.nodeName",
+			Envar:      "KUBESOLO_NODE_NAME",
+			Get:        func(c *types.Config) any { return c.Kubernetes.NodeName },
+			Set:        func(c *types.Config, v string) error { c.Kubernetes.NodeName = v; return nil },
+		},
+		{
 			ConfigPath: "kubernetes.apiServer.extraSANs",
 			Flag:       "apiserver-extra-sans",
 			Envar:      "KUBESOLO_APISERVER_EXTRA_SANS",

--- a/internal/config/testdata/embedded/container-mode.json
+++ b/internal/config/testdata/embedded/container-mode.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/cpu-manager-static.json
+++ b/internal/config/testdata/embedded/cpu-manager-static.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/custom-base-path.json
+++ b/internal/config/testdata/embedded/custom-base-path.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "10.0.0.5",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/d2k-enabled.json
+++ b/internal/config/testdata/embedded/d2k-enabled.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/defaults.json
+++ b/internal/config/testdata/embedded/defaults.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "192.168.1.10",
   "NodeIPSpecified": false,
   "MTU": 1500,

--- a/internal/config/testdata/embedded/disable-ipv6.json
+++ b/internal/config/testdata/embedded/disable-ipv6.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/embedded-runtime-explicit-zero.json
+++ b/internal/config/testdata/embedded/embedded-runtime-explicit-zero.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/external-runtime.json
+++ b/internal/config/testdata/embedded/external-runtime.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/extra-sans-empty.json
+++ b/internal/config/testdata/embedded/extra-sans-empty.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/extra-sans-multiple.json
+++ b/internal/config/testdata/embedded/extra-sans-multiple.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/extra-sans-single.json
+++ b/internal/config/testdata/embedded/extra-sans-single.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/load-balancer-distinct-ip.json
+++ b/internal/config/testdata/embedded/load-balancer-distinct-ip.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "10.0.0.5",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/load-balancer-off.json
+++ b/internal/config/testdata/embedded/load-balancer-off.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/metrics-enabled.json
+++ b/internal/config/testdata/embedded/metrics-enabled.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/mtu-pinned.json
+++ b/internal/config/testdata/embedded/mtu-pinned.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 1400,

--- a/internal/config/testdata/embedded/node-ip-pinned.json
+++ b/internal/config/testdata/embedded/node-ip-pinned.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "10.0.0.5",
   "NodeIPSpecified": true,
   "MTU": 0,

--- a/internal/config/testdata/embedded/node-name-explicit.json
+++ b/internal/config/testdata/embedded/node-name-explicit.json
@@ -1,5 +1,5 @@
 {
-  "NodeName": "",
+  "NodeName": "talos-cp-1",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,
@@ -90,8 +90,8 @@
   "PortainerEdgeImage": "",
   "ContainerMode": false,
   "DisableIPv6": false,
-  "D2K": true,
-  "D2KNamespace": "workloads",
+  "D2K": false,
+  "D2KNamespace": "",
   "D2KCerts": {
     "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
     "ServerCert": "/var/lib/kubesolo/pki/d2k/server.crt",

--- a/internal/config/testdata/embedded/node-name-falls-back-to-hostname.json
+++ b/internal/config/testdata/embedded/node-name-falls-back-to-hostname.json
@@ -1,5 +1,5 @@
 {
-  "NodeName": "",
+  "NodeName": "edge-box-7",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,
@@ -90,8 +90,8 @@
   "PortainerEdgeImage": "",
   "ContainerMode": false,
   "DisableIPv6": false,
-  "D2K": true,
-  "D2KNamespace": "workloads",
+  "D2K": false,
+  "D2KNamespace": "",
   "D2KCerts": {
     "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
     "ServerCert": "/var/lib/kubesolo/pki/d2k/server.crt",

--- a/internal/config/testdata/embedded/node-name-normalised.json
+++ b/internal/config/testdata/embedded/node-name-normalised.json
@@ -1,0 +1,111 @@
+{
+  "NodeName": "talos-cp-1",
+  "NodeIP": "",
+  "NodeIPSpecified": false,
+  "MTU": 0,
+  "MTUSpecified": false,
+  "PKIDir": "/var/lib/kubesolo/pki",
+  "PKICADir": "/var/lib/kubesolo/pki/ca",
+  "PKIAdminDir": "/var/lib/kubesolo/pki/admin",
+  "PKIAPIServerDir": "/var/lib/kubesolo/pki/apiserver",
+  "PKIControllerDir": "/var/lib/kubesolo/pki/controller-manager",
+  "PKIKubeletDir": "/var/lib/kubesolo/pki/kubelet",
+  "PKIWebhookDir": "/var/lib/kubesolo/pki/webhook",
+  "PKIRequestHeaderDir": "/var/lib/kubesolo/pki/request-header",
+  "AdminKubeconfigFile": "/var/lib/kubesolo/pki/admin/admin.kubeconfig",
+  "KubeletCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Cert": "/var/lib/kubesolo/pki/kubelet/kubelet.crt",
+    "Key": "/var/lib/kubesolo/pki/kubelet/kubelet.key"
+  },
+  "APIServerCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Cert": "/var/lib/kubesolo/pki/apiserver/apiserver.crt",
+    "Key": "/var/lib/kubesolo/pki/apiserver/apiserver.key"
+  },
+  "ControllerManagerCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Cert": "/var/lib/kubesolo/pki/controller-manager/controller-manager.crt",
+    "Key": "/var/lib/kubesolo/pki/controller-manager/controller-manager.key"
+  },
+  "AdminCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Cert": "/var/lib/kubesolo/pki/admin/admin.crt",
+    "Key": "/var/lib/kubesolo/pki/admin/admin.key"
+  },
+  "WebhookCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Cert": "/var/lib/kubesolo/pki/webhook/webhook.crt",
+    "Key": "/var/lib/kubesolo/pki/webhook/webhook.key"
+  },
+  "CACerts": {
+    "Cert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "Key": "/var/lib/kubesolo/pki/ca/ca.key"
+  },
+  "RequestHeaderCerts": {
+    "CACert": "/var/lib/kubesolo/pki/request-header/request-header-ca.crt",
+    "CAKey": "/var/lib/kubesolo/pki/request-header/request-header-ca.key",
+    "ClientCert": "/var/lib/kubesolo/pki/request-header/request-header-client.crt",
+    "ClientKey": "/var/lib/kubesolo/pki/request-header/request-header-client.key"
+  },
+  "ContainerdDir": "/var/lib/kubesolo/containerd",
+  "ContainerdSocketFile": "/var/lib/kubesolo/containerd/containerd.sock",
+  "ContainerdBinaryFile": "/var/lib/kubesolo/containerd/containerd",
+  "ContainerdImagesDir": "/var/lib/kubesolo/containerd/images",
+  "ContainerdConfigFile": "/var/lib/kubesolo/containerd/config.toml",
+  "ContainerdShimBinaryFile": "/var/lib/kubesolo/containerd/containerd-shim-runc-v2",
+  "ContainerdRootDir": "/var/lib/kubesolo/containerd/root",
+  "ContainerdStateDir": "/var/lib/kubesolo/containerd/state",
+  "ContainerdRegistryConfigDir": "/var/lib/kubesolo/containerd/registry",
+  "ContainerdCNIDir": "/var/lib/kubesolo/containerd/cni",
+  "ContainerdCNIPluginsDir": "/var/lib/kubesolo/containerd/cni/plugins",
+  "ContainerdCNIConfigDir": "/var/lib/kubesolo/containerd/cni/conf",
+  "ContainerdCNIConfigFile": "/var/lib/kubesolo/containerd/cni/conf/10-bridge.conflist",
+  "CrunBinaryFile": "/var/lib/kubesolo/containerd/crun",
+  "RuntimeExternal": false,
+  "RuntimeEndpoint": "unix:///var/lib/kubesolo/containerd/containerd.sock",
+  "RuntimeSocketPath": "/var/lib/kubesolo/containerd/containerd.sock",
+  "RuntimeCgroupDriver": "",
+  "KubeletDir": "/var/lib/kubesolo/kubelet",
+  "KubeletConfigDir": "/var/lib/kubesolo/kubelet/config",
+  "KubeletConfigFile": "/var/lib/kubesolo/kubelet/config/config.yaml",
+  "KubeletKubeConfigFile": "/var/lib/kubesolo/pki/kubelet/kubelet.kubeconfig",
+  "KubeletPluginsDir": "/var/lib/kubesolo/kubelet/volumeplugins",
+  "APIServerDir": "/var/lib/kubesolo/apiserver",
+  "ServiceAccountKeyFile": "/var/lib/kubesolo/pki/apiserver/service-account.key",
+  "APIServerExtraSANs": null,
+  "KineDir": "/var/lib/kubesolo/kine/db",
+  "KineSocketFile": "/var/lib/kubesolo/kine/db/socket",
+  "ControllerDir": "/var/lib/kubesolo/controller-manager/config",
+  "WebhookDir": "/var/lib/kubesolo/pki/webhook",
+  "PortainerEdgeImageFile": "/var/lib/kubesolo/containerd/images/portainer-agent.tar.gz",
+  "CorednsImageFile": "/var/lib/kubesolo/containerd/images/coredns.tar.gz",
+  "SandboxImageFile": "/var/lib/kubesolo/containerd/images/pause.tar.gz",
+  "LocalPathProvisionerImageFile": "/var/lib/kubesolo/containerd/images/local-path-provisioner.tar.gz",
+  "D2KImageFile": "/var/lib/kubesolo/containerd/images/d2k.tar.gz",
+  "LoadBalancer": false,
+  "LoadBalancerIP": "",
+  "LocalPathStorageDir": "/var/lib/kubesolo/local-path-storage",
+  "IsPortainerEdge": false,
+  "PortainerEdgeImage": "",
+  "ContainerMode": false,
+  "DisableIPv6": false,
+  "D2K": false,
+  "D2KNamespace": "",
+  "D2KCerts": {
+    "CACert": "/var/lib/kubesolo/pki/ca/ca.crt",
+    "ServerCert": "/var/lib/kubesolo/pki/d2k/server.crt",
+    "ServerKey": "/var/lib/kubesolo/pki/d2k/server.key",
+    "ClientCert": "/var/lib/kubesolo/pki/d2k/client.crt",
+    "ClientKey": "/var/lib/kubesolo/pki/d2k/client.key"
+  },
+  "Metrics": {
+    "enabled": false,
+    "bindAddress": ""
+  },
+  "CPUManager": {
+    "policy": "",
+    "reservedCPUs": ""
+  },
+  "SystemReserved": null
+}

--- a/internal/config/testdata/embedded/portainer-edge-full.json
+++ b/internal/config/testdata/embedded/portainer-edge-full.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/portainer-edge-id-only.json
+++ b/internal/config/testdata/embedded/portainer-edge-id-only.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/portainer-edge-key-only.json
+++ b/internal/config/testdata/embedded/portainer-edge-key-only.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/config/testdata/embedded/zero.json
+++ b/internal/config/testdata/embedded/zero.json
@@ -1,4 +1,5 @@
 {
+  "NodeName": "",
   "NodeIP": "",
   "NodeIPSpecified": false,
   "MTU": 0,

--- a/internal/core/embedded/host.go
+++ b/internal/core/embedded/host.go
@@ -43,6 +43,16 @@ func ensureHostDependencies(embedded types.Embedded) error {
 	// with crictl, and it dangles once kubesolo is removed, which makes the runtime
 	// log a CNI load failure for every sandbox it creates.
 	cniConfigFile := filepath.Join(types.DefaultStandardCNIConfDir, types.DefaultCNIConfigName)
+
+	// A previous run with the embedded containerd symlinks this path into the
+	// kubesolo data directory. os.WriteFile follows that symlink, so leaving it in
+	// place would either write the config into the embedded tree or, once the
+	// target is gone, fail with ENOENT against a directory that plainly exists.
+	if filesystem.RemoveIfSymlink(cniConfigFile) {
+		log.Info().Str("component", "embedded").
+			Msgf("removed the cni config symlink at %s left by a previous run with the embedded containerd", cniConfigFile)
+	}
+
 	if err := writeCNIConfigFile(cniConfigFile, embedded.MTU); err != nil {
 		return fmt.Errorf("%v (the directory has to be writable, so on a read-only rootfs it must be mounted read-write)", err)
 	}

--- a/internal/core/pki/options.go
+++ b/internal/core/pki/options.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/portainer/kubesolo/internal/runtime/network"
-	"github.com/portainer/kubesolo/internal/system"
 	"github.com/portainer/kubesolo/types"
 	"github.com/rs/zerolog/log"
 )
@@ -53,11 +52,11 @@ func defaultCertOptions(certType CertificateType, embedded types.Embedded) CertO
 		opts.KeyDir = embedded.CACerts.Key
 
 	case KubeletCert:
-		hostname := system.GetHostname()
+		nodeName := embedded.NodeName
 
-		opts.CommonName = fmt.Sprintf("system:node:%s", hostname)
+		opts.CommonName = fmt.Sprintf("system:node:%s", nodeName)
 		opts.Organization = []string{"system:nodes"}
-		opts.DNSNames = []string{hostname, "localhost"}
+		opts.DNSNames = []string{nodeName, "localhost"}
 		opts.SignerCertDir = embedded.CACerts.Cert
 		opts.SignerKeyDir = embedded.CACerts.Key
 		opts.CertDir = filepath.Join(embedded.PKIKubeletDir, "kubelet.crt")

--- a/pkg/kubernetes/kubelet/service.go
+++ b/pkg/kubernetes/kubelet/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/portainer/kubesolo/internal/system"
 	"github.com/portainer/kubesolo/types"
 )
 
@@ -57,7 +56,7 @@ func NewService(ctx context.Context, cancel context.CancelFunc, kubeletReady cha
 		caFile:                embedded.KubeletCerts.CACert,
 		certFile:              embedded.KubeletCerts.Cert,
 		keyFile:               embedded.KubeletCerts.Key,
-		nodeName:              system.GetHostname(),
+		nodeName:              embedded.NodeName,
 		adminKubeconfig:       embedded.AdminKubeconfigFile,
 		containerMode:         embedded.ContainerMode,
 		disableIPv6:           embedded.DisableIPv6,

--- a/pkg/kubernetes/kubeproxy/flags.go
+++ b/pkg/kubernetes/kubeproxy/flags.go
@@ -35,10 +35,15 @@ func (s *service) configureKubeProxyFlags(command *cobra.Command) {
 	// proxy mode and conntrack settings
 	_ = flags.Set("proxy-mode", proxyMode)
 	if s.containerMode {
-		// In container mode, avoid writing to /proc/sys/net/netfilter/nf_conntrack_max
-		// which may be read-only depending on the container runtime.
+		// In container mode, avoid writing to /proc/sys/net/netfilter which may be
+		// read-only depending on the container runtime. Zero leaves the kernel
+		// value alone. The timeouts matter as much as the maximums: kube-proxy
+		// exits outright when it cannot write them. The UDP timeouts already
+		// default to zero, so only these four are set.
 		_ = flags.Set("conntrack-max-per-core", "0")
 		_ = flags.Set("conntrack-min", "0")
+		_ = flags.Set("conntrack-tcp-timeout-established", "0s")
+		_ = flags.Set("conntrack-tcp-timeout-close-wait", "0s")
 	}
 
 	if proxyMode == "iptables" {

--- a/pkg/kubernetes/kubeproxy/flags_test.go
+++ b/pkg/kubernetes/kubeproxy/flags_test.go
@@ -1,0 +1,51 @@
+package kubeproxy
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kube-proxy/app"
+)
+
+// TestContainerModeLeavesConntrackAlone pins the whole conntrack set to zero in
+// container mode.
+//
+// kube-proxy writes each of these to /proc/sys/net/netfilter, which runc mounts
+// read-only unless the runtime clears it. Zero is the only value that stops the
+// write. Missing any single one of them is fatal — kube-proxy exits with
+// "read-only file system" — and the maximums alone are not enough, which is the
+// bug this pins.
+func TestContainerModeLeavesConntrackAlone(t *testing.T) {
+	zeroed := []string{
+		"conntrack-max-per-core",
+		"conntrack-min",
+		"conntrack-tcp-timeout-established",
+		"conntrack-tcp-timeout-close-wait",
+		"conntrack-udp-timeout",
+		"conntrack-udp-timeout-stream",
+	}
+
+	command := app.NewProxyCommand()
+	(&service{containerMode: true}).configureKubeProxyFlags(command)
+
+	for _, name := range zeroed {
+		flag := command.Flags().Lookup(name)
+		if flag == nil {
+			t.Errorf("%s: flag not found on the kube-proxy command", name)
+			continue
+		}
+		if got := flag.Value.String(); got != "0" && got != "0s" {
+			t.Errorf("%s = %q, want zero so kube-proxy leaves the kernel value alone", name, got)
+		}
+	}
+}
+
+// Outside container mode kube-proxy owns the host and should tune conntrack as
+// it normally would, so the defaults must be left in place.
+func TestHostModeKeepsConntrackDefaults(t *testing.T) {
+	command := app.NewProxyCommand()
+	(&service{containerMode: false}).configureKubeProxyFlags(command)
+
+	if got := command.Flags().Lookup("conntrack-tcp-timeout-established").Value.String(); got == "0s" {
+		t.Error("conntrack-tcp-timeout-established was zeroed outside container mode")
+	}
+}

--- a/pkg/kubernetes/kubeproxy/flags_test.go
+++ b/pkg/kubernetes/kubeproxy/flags_test.go
@@ -33,10 +33,16 @@ func TestContainerModeLeavesConntrackAlone(t *testing.T) {
 			t.Errorf("%s: flag not found on the kube-proxy command", name)
 			continue
 		}
-		if got := flag.Value.String(); got != "0" && got != "0s" {
+		if got := flag.Value.String(); !isZero(got) {
 			t.Errorf("%s = %q, want zero so kube-proxy leaves the kernel value alone", name, got)
 		}
 	}
+}
+
+// isZero covers both spellings: the counts render as "0" and the durations as
+// "0s".
+func isZero(value string) bool {
+	return value == "0" || value == "0s"
 }
 
 // Outside container mode kube-proxy owns the host and should tune conntrack as
@@ -45,7 +51,14 @@ func TestHostModeKeepsConntrackDefaults(t *testing.T) {
 	command := app.NewProxyCommand()
 	(&service{containerMode: false}).configureKubeProxyFlags(command)
 
-	if got := command.Flags().Lookup("conntrack-tcp-timeout-established").Value.String(); got == "0s" {
-		t.Error("conntrack-tcp-timeout-established was zeroed outside container mode")
+	const name = "conntrack-tcp-timeout-established"
+
+	flag := command.Flags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("%s: flag not found on the kube-proxy command", name)
+	}
+
+	if got := flag.Value.String(); isZero(got) {
+		t.Errorf("%s = %q, want the kube-proxy default outside container mode", name, got)
 	}
 }

--- a/types/config.go
+++ b/types/config.go
@@ -87,6 +87,14 @@ type RuntimeConfig struct {
 // likeliest settings to become configurable next. Everything else in this
 // document is single-purpose and stays at the top level.
 type KubernetesConfig struct {
+	// NodeName is the name of the single node this control plane manages. Empty
+	// means the hostname, which is what a KubeSolo-managed kubelet registers as.
+	//
+	// It has to be set when the kubelet is external and registers under a name
+	// this host does not share: the NodeSetter webhook pins every pod to this
+	// name, so a mismatch leaves the whole cluster Pending.
+	NodeName string `json:"nodeName,omitempty"`
+
 	APIServer APIServerConfig `json:"apiServer"`
 	Kubelet   KubeletConfig   `json:"kubelet"`
 }

--- a/types/config.go
+++ b/types/config.go
@@ -88,11 +88,11 @@ type RuntimeConfig struct {
 // document is single-purpose and stays at the top level.
 type KubernetesConfig struct {
 	// NodeName is the name of the single node this control plane manages. Empty
-	// means the hostname, which is what a KubeSolo-managed kubelet registers as.
+	// means the hostname.
 	//
-	// It has to be set when the kubelet is external and registers under a name
-	// this host does not share: the NodeSetter webhook pins every pod to this
-	// name, so a mismatch leaves the whole cluster Pending.
+	// It is trimmed and lowercased, because that is what the kubelet does to the
+	// name before registering it, and the NodeSetter webhook pins every pod to
+	// this name — a mismatch leaves the whole cluster Pending.
 	NodeName string `json:"nodeName,omitempty"`
 
 	APIServer APIServerConfig `json:"apiServer"`

--- a/types/types.go
+++ b/types/types.go
@@ -61,6 +61,12 @@ type D2KCertificatePaths struct {
 }
 
 type Embedded struct {
+	// NodeName is the name of the single node this control plane manages. It is
+	// the kubelet's registered node name, the subject of its client certificate
+	// and its RBAC binding, and the node the NodeSetter webhook pins pods to.
+	// Resolved from kubernetes.nodeName, falling back to the hostname.
+	NodeName string
+
 	// System Node IP
 	NodeIP string
 


### PR DESCRIPTION
Three defects surfaced by running KubeSolo as a container on Talos Linux, none of them Talos-specific.

The image selected a masquerade backend it did not carry. EnsurePodMasquerade picks nftables when /proc/net/ip_tables_names is absent, but the image installed iptables only, so on any nft-only host KubeSolo died at startup with `exec: "nft": executable file not found`. Never seen before because the e2e harness runs on Ubuntu, where ip_tables is loaded.

kube-proxys container-mode conntrack guard covered the maximums but not the timeouts. runc mounts /proc/sys read-only unless the runtime clears it, which Dockers --privileged does and other runtimes do not, so kube-proxy exited with `read-only file system` on a host where everything else worked. The UDP timeouts already default to zero and are left alone; the test asserts the whole set so a changed default is caught.

Migrating from the embedded containerd to a host-managed runtime left a stale CNI config symlink. os.WriteFile follows it, so the host-runtime path failed with ENOENT against a directory that plainly existed.